### PR TITLE
Add control check for `codebuild-project-source-repo-url-check`. Closes #239 

### DIFF
--- a/conformance_pack/codebuild.sp
+++ b/conformance_pack/codebuild.sp
@@ -14,3 +14,14 @@ control "codebuild_project_plaintext_env_variables_no_sensitive_aws_values" {
     nist_cyber_security = "true"
   })
 }
+
+control "codebuild_project_source_repo_oauth_configured" {
+  title       = "CodeBuild GitHub or Bitbucket source repository URLs should use OAuth"
+  description = "Ensure the GitHub or Bitbucket source repository URL does not contain personal access tokens, user name and password within AWS Codebuild project environments."
+  sql         = query.codebuild_project_source_repo_oauth_configured.sql
+
+  tags = merge(local.conformance_pack_codebuild_common_tags, {
+    hipaa               = "true"
+    nist_cyber_security = "true"
+  })
+}

--- a/foundational_security/codebuild.sp
+++ b/foundational_security/codebuild.sp
@@ -1,0 +1,41 @@
+locals {
+  foundational_security_codebuild_common_tags = merge(local.foundational_security_common_tags, {
+    service = "codebuild"
+  })
+}
+
+benchmark "foundational_security_codebuild" {
+  title         = "CodeBuild"
+  documentation = file("./foundational_security/docs/foundational_security_codebuild.md")
+  children = [
+    control.foundational_security_codebuild_1,
+    control.foundational_security_codebuild_2
+  ]
+  tags          = local.foundational_security_codebuild_common_tags
+}
+
+control "foundational_security_codebuild_1" {
+  title         = "1 CodeBuild GitHub or Bitbucket source repository URLs should use OAuth"
+  description   = "Authentication credentials should never be stored or transmitted in clear text or appear in the repository URL. Instead of personal access tokens or user name and password, you should use OAuth to grant authorization for accessing GitHub or Bitbucket repositories. Using personal access tokens or a user name and password could expose your credentials to unintended data exposure and unauthorized access."
+  severity      = "critical"
+  sql           = query.codebuild_project_source_repo_oauth_configured.sql
+  documentation = file("./foundational_security/docs/foundational_security_codebuild_1.md")
+
+  tags = merge(local.foundational_security_codebuild_common_tags, {
+    foundational_security_item_id  = "codebuild_1"
+    foundational_security_category = "secure_development"
+  })
+}
+
+control "foundational_security_codebuild_2" {
+  title         = "2 CodeBuild project environment variables should not contain clear text credentials"
+  description   = "This control checks whether the project contains the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. Authentication credentials AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY should never be stored in clear text, as this could lead to unintended data exposure and unauthorized access."
+  severity      = "critical"
+  sql           = query.codebuild_project_plaintext_env_variables_no_sensitive_aws_values.sql
+  documentation = file("./foundational_security/docs/foundational_security_codebuild_2.md")
+
+  tags = merge(local.foundational_security_codebuild_common_tags, {
+    foundational_security_item_id  = "codebuild_2"
+    foundational_security_category = "secure_development"
+  })
+}

--- a/foundational_security/foundational_security.sp
+++ b/foundational_security/foundational_security.sp
@@ -15,6 +15,7 @@ benchmark "foundational_security" {
     benchmark.foundational_security_autoscaling,
     benchmark.foundational_security_cloudfront,
     benchmark.foundational_security_cloudtrail,
+    benchmark.foundational_security_codebuild,
     benchmark.foundational_security_config,
     benchmark.foundational_security_dms,
     benchmark.foundational_security_dynamodb,

--- a/hipaa/164_308_a_1_ii_b.sp
+++ b/hipaa/164_308_a_1_ii_b.sp
@@ -8,6 +8,7 @@ benchmark "hipaa_164_308_a_1_ii_b" {
     control.cloudtrail_trail_logs_encrypted_with_kms_cmk,
     control.cloudtrail_trail_validation_enabled,
     control.codebuild_project_plaintext_env_variables_no_sensitive_aws_values,
+    control.codebuild_project_source_repo_oauth_configured,
     control.dms_replication_instance_not_publicly_accessible,
     control.dynamodb_table_auto_scaling_enabled,
     control.dynamodb_table_point_in_time_recovery_enabled,

--- a/nist_cyber_security_v11/function_de.sp
+++ b/nist_cyber_security_v11/function_de.sp
@@ -97,6 +97,7 @@ benchmark "nist_cyber_security_v11_de_ae_5" {
 
   children = [
     control.cloudwatch_alarm_action_enabled,
+    control.codebuild_project_source_repo_oauth_configured,
     control.lambda_function_dead_letter_queue_configured
   ]
 

--- a/pci_v321/codebuild.sp
+++ b/pci_v321/codebuild.sp
@@ -8,9 +8,23 @@ benchmark "pci_v321_codebuild" {
   title         = "CodeBuild"
   documentation = file("./pci_v321/docs/pci_v321_codebuild.md")
   children = [
+    control.pci_v321_codebuild_1,
     control.pci_v321_codebuild_2
   ]
   tags          = local.pci_v321_codebuild_common_tags
+}
+
+control "pci_v321_codebuild_1" {
+  title         = "1 CodeBuild GitHub or Bitbucket source repository URLs should use OAuth"
+  description   = "This control checks whether the GitHub or Bitbucket source repository URL contains either personal access tokens or a user name and password."
+  severity      = "critical"
+  sql           = query.codebuild_project_source_repo_oauth_configured.sql
+  documentation = file("./pci_v321/docs/pci_v321_codebuild_1.md")
+
+  tags = merge(local.pci_v321_codebuild_common_tags, {
+    pci_item_id      = "codebuild_1"
+    pci_requirements = "8.2.1"
+  })
 }
 
 control "pci_v321_codebuild_2" {

--- a/query/codebuild/codebuild_project_source_repo_oauth_configured.sql
+++ b/query/codebuild/codebuild_project_source_repo_oauth_configured.sql
@@ -1,0 +1,20 @@
+select
+  -- Required Columns
+  p.arn as resource,
+  case
+    when p.source ->> 'Type' not in ('GITHUB', 'BITBUCKET') then 'skip'
+    when c.auth_type = 'OAUTH' then 'ok'
+    else 'alarm'
+  end as status,
+  case
+    when p.source ->> 'Type' = 'NO_SOURCE' then p.title || ' doesn''t have input source code.'
+    when p.source ->> 'Type' not in ('GITHUB', 'BITBUCKET') then p.title || ' source code isn''t in GitHub/Bitbucket repository.'
+    when c.auth_type = 'OAUTH' then p.title || ' using OAuth to connect source repository.'
+    else p.title || ' not using OAuth to connect source repository.'
+  end as reason,
+  -- Additional Dimensions
+  p.region,
+  p.account_id
+from
+  test_aab.aws_codebuild_project as p
+  left join test_aab.aws_codebuild_source_credential as c on (p.region = c.region and p.source ->> 'Type' = c.server_type);

--- a/query/codebuild/codebuild_project_source_repo_oauth_configured.sql
+++ b/query/codebuild/codebuild_project_source_repo_oauth_configured.sql
@@ -16,5 +16,5 @@ select
   p.region,
   p.account_id
 from
-  test_aab.aws_codebuild_project as p
-  left join test_aab.aws_codebuild_source_credential as c on (p.region = c.region and p.source ->> 'Type' = c.server_type);
+  aws_codebuild_project as p
+  left join aws_codebuild_source_credential as c on (p.region = c.region and p.source ->> 'Type' = c.server_type);


### PR DESCRIPTION
### Checklist
- [x] #239 

**_Check description_**: `CodeBuild GitHub or Bitbucket source repository URLs should use OAuth`
**_Config Rule_**           : [codebuild-project-source-repo-url-check](https://docs.aws.amazon.com/config/latest/developerguide/codebuild-project-source-repo-url-check.html)
**_Frameworks updated_**
```
HIPAA    - 164.308(a)(1)(ii)(B)
FSBP     - CodeBuild.1
PCI DSS  - CodeBuild.1
NIST CSF - DE.AE-5
```
