### PR TITLE
Update queries to check policy attachment & separation to validate all  vs custom iam policies. Fixes #277 Closes #280

### DIFF
--- a/cis_v130/section_1.sp
+++ b/cis_v130/section_1.sp
@@ -247,7 +247,7 @@ control "cis_v130_1_15" {
 control "cis_v130_1_16" {
   title         = "1.16 Ensure IAM policies that allow full \"*:*\" administrative privileges are not attached"
   description   = "IAM policies are the means by which privileges are granted to users, groups, or roles. It is recommended and considered a standard security advice to grant least privilege -that is, granting only the permissions required to perform a task. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of allowing full administrative privileges."
-  sql           = query.iam_policy_no_star_star.sql
+  sql           = query.iam_all_policy_no_star_star.sql
   documentation = file("./cis_v130/docs/cis_v130_1_16.md")
 
   tags = merge(local.cis_v130_1_common_tags, {

--- a/cis_v140/section_1.sp
+++ b/cis_v140/section_1.sp
@@ -246,7 +246,7 @@ control "cis_v140_1_15" {
 control "cis_v140_1_16" {
   title         = "1.16 Ensure IAM policies that allow full \"*:*\" administrative privileges are not attached"
   description   = "IAM policies are the means by which privileges are granted to users, groups, or roles. It is recommended and considered a standard security advice to grant least privilege -that is, granting only the permissions required to perform a task. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of allowing full administrative privileges."
-  sql           = query.iam_policy_no_star_star.sql
+  sql           = query.iam_all_policy_no_star_star.sql
   documentation = file("./cis_v140/docs/cis_v140_1_16.md")
 
   tags = merge(local.cis_v140_1_common_tags, {

--- a/foundational_security/iam.sp
+++ b/foundational_security/iam.sp
@@ -25,7 +25,7 @@ control "foundational_security_iam_1" {
   title         = "1 IAM policies should not allow full '*' administrative privileges"
   description   = "This control checks whether the default version of IAM policies (also known as customer managed policies) has administrator access that includes a statement with 'Effect': 'Allow' with 'Action': '*' over 'Resource': '*'. The control only checks the customer managed policies that you create. It does not check inline and AWS managed policies."
   severity      = "high"
-  sql           = query.iam_policy_no_star_star.sql
+  sql           = query.iam_custom_policy_no_star_star.sql
   documentation = file("./foundational_security/docs/foundational_security_iam_1.md")
 
   tags = merge(local.foundational_security_iam_common_tags, {
@@ -129,7 +129,7 @@ control "foundational_security_iam_21" {
   title         = "21 IAM customer managed policies that you create should not allow wildcard actions for services"
   description   = "This control checks whether the IAM identity-based policies that you create have Allow statements that use the * wildcard to grant permissions for all actions on any service. The control fails if any policy statement includes 'Effect': 'Allow' with 'Action': 'Service:*'."
   severity      = "low"
-  sql           = query.iam_custom_policy_no_star_star.sql
+  sql           = query.iam_custom_policy_no_service_wild_card.sql
   documentation = file("./foundational_security/docs/foundational_security_iam_21.md")
 
   tags = merge(local.foundational_security_iam_common_tags, {

--- a/query/iam/iam_all_policy_no_star_star.sql
+++ b/query/iam/iam_all_policy_no_star_star.sql
@@ -1,4 +1,3 @@
--- This query checks the customer managed policies having * access and attached to IAM resource(s)
 with star_access_policies as (
   select
     arn,
@@ -16,7 +15,6 @@ with star_access_policies as (
       or action = '*:*'
       )
   )
-  -- Checking attachment
   and attachment_count !=0
   group by arn
  )
@@ -33,7 +31,4 @@ select
   p.account_id
 from
   aws_iam_policy as p
-  left join star_access_policies as s on p.arn = s.arn
-where
-  -- Filter only customer managed policies
-  p.arn not like 'arn:aws:iam::aws:policy%';
+  left join star_access_policies as s on p.arn = s.arn;

--- a/query/iam/iam_custom_policy_no_service_wild_card.sql
+++ b/query/iam/iam_custom_policy_no_service_wild_card.sql
@@ -1,0 +1,33 @@
+with wildcard_action_policies as (
+  select
+    arn,
+    count(*) as statements_num
+  from
+    aws_iam_policy,
+    jsonb_array_elements(policy_std -> 'Statement') as s,
+    jsonb_array_elements_text(s -> 'Resource') as resource,
+    jsonb_array_elements_text(s -> 'Action') as action
+  where
+    is_aws_managed = 'false'
+    and s ->> 'Effect' = 'Allow'
+    and resource = '*'
+    and action like '%:*'
+  group by
+    arn
+)
+select
+  -- Required Columns
+  a.arn as resource,
+  case
+    when b.arn is null then 'ok'
+    else 'alarm'
+  end status,
+  a.name || ' contains ' || coalesce(b.statements_num,0)  ||
+     ' statements that allow action "Service:*" on resource "*".' as reason,
+  -- Additional Dimensions
+  a.account_id
+from
+  aws_iam_policy as a
+  left join wildcard_action_policies as b on a.arn = b.arn
+where
+  a.arn not like 'arn:aws:iam::aws:policy%'

--- a/query/iam/iam_custom_policy_no_service_wild_card.sql
+++ b/query/iam/iam_custom_policy_no_service_wild_card.sql
@@ -30,4 +30,4 @@ from
   aws_iam_policy as a
   left join wildcard_action_policies as b on a.arn = b.arn
 where
-  a.arn not like 'arn:aws:iam::aws:policy%'
+  a.arn not like 'arn:aws:iam::aws:policy%';


### PR DESCRIPTION
### Checklist
- [ ] https://github.com/turbot/steampipe-mod-aws-compliance/issues/277
- [ ] https://github.com/turbot/steampipe-mod-aws-compliance/issues/280

1. **`foundational_security_iam_1 `** earlier using `iam_policy_no_star_star.sql` was not valid, as it was not checking attachment, now it will use query `iam_custom_policy_no_star_star.sql`  which is added with attachment check and restricted to customer managed policies.

2. `iam_policy_no_star_star` has occurrences in other compliance mods, hence retaining it as is. `iam_custom_policy_no_star_star.sql` is only used in **iam.sp** file hence safe.

3. **` foundational_security_iam_21`** , now uses new query **`iam_custom_policy_no_service_wild_card.sql `** . Earlier it was using the query `iam_custom_policy_no_star_star.sql`  which was used by `foundational_security_iam_1` (mentioned above). As per **` foundational_security_iam_21`** requirement, control checks for `service:*` pattern. 
(This new query is a single occurrence, safe to proceed)

4. Introduced new query **`iam_all_policy_no_star_star.sql`** for **cis_v140_1_16**  earlier it was using the wrong query i.e. `iam_policy_no_star_star.sql ` _(this was again restrictive to the only customer managed and there was no attachment check),_ **cis_v140_1_16**  should check all policies inclusive AWS ones which are attached.