### PR TITLE
backup_plan_min_retention_35_days needs to handle rules with 'Never expire'. Closes #313

### DIFF
--- a/query/backup/backup_plan_min_retention_35_days.sql
+++ b/query/backup/backup_plan_min_retention_35_days.sql
@@ -1,27 +1,33 @@
-with backup_pan_retention as (
+with all_plans as (
   select
-    backup_plan_id,
-    (r -> 'Lifecycle' ->> 'DeleteAfterDays')::int as DeleteAfterDays
+    arn,
+    r as Rules,
+    title,
+    region,
+    account_id
   from
     aws_backup_plan,
     jsonb_array_elements(backup_plan -> 'Rules') as r
 )
 select
   -- Required Columns
-  a.arn as resource,
+  -- The resource ARN can be duplicate as we are checking all the associated rules to the backup-plan
+  -- Backup plans are composed of one or more backup rules.
+  -- https://docs.aws.amazon.com/aws-backup/latest/devguide/creating-a-backup-plan.html
+  r.arn as resource,
   case
-    when r.backup_plan_id is null then 'alarm'
-    when r.DeleteAfterDays >= 35 then 'ok'
+    when r.Rules is null then 'alarm'
+    when r.Rules ->> 'Lifecycle' is null then 'ok'
+    when (r.Rules -> 'Lifecycle' ->> 'DeleteAfterDays')::int >= 37 then 'ok'
     else 'alarm'
   end as status,
   case
-    when r.backup_plan_id is null then a.title || ' retention period not set.'
-    when r.DeleteAfterDays >= 35 then a.title || ' retention period set to ' || r.DeleteAfterDays || ' days.'
-    else a.title || ' retention period not set to ' || r.DeleteAfterDays || ' days.'
+    when r.Rules is null then r.title || ' retention period not set.'
+    when r.Rules ->> 'Lifecycle' is null then (r.Rules ->> 'RuleName') || ' retention period set to never expire.'
+    else (r.Rules ->> 'RuleName') || ' retention period set to ' || (r.Rules -> 'Lifecycle' ->> 'DeleteAfterDays') || ' days.'
   end as reason,
   -- Additional Dimensions
-  a.region,
-  a.account_id
+  r.region,
+  r.account_id
 from
-  aws_backup_plan as a
-  left join backup_pan_retention as r on a.backup_plan_id = r.backup_plan_id;
+  all_plans as r;


### PR DESCRIPTION
### Checklist
- [ ] Issue(s) linked
```
> with all_plans as (
  select
    arn,
    r as Rules,
    title,
    region,
    account_id
  from
    aws_backup_plan,
    jsonb_array_elements(backup_plan -> 'Rules') as r
)
select
  -- Required Columns
  -- The resource ARN can be duplicate as we are checking all the associated rules to the backup-plan
  -- Backup plans are composed of one or more backup rules.
  -- https://docs.aws.amazon.com/aws-backup/latest/devguide/creating-a-backup-plan.html
  r.arn as resource,
  case
    when r.Rules is null then 'alarm'
    when r.Rules ->> 'Lifecycle' is null then 'ok'
    when (r.Rules -> 'Lifecycle' ->> 'DeleteAfterDays')::int >= 37 then 'ok'
    else 'alarm'
  end as status,
  case
    when r.Rules is null then r.title || ' retention period not set.'
    when r.Rules ->> 'Lifecycle' is null then (r.Rules ->> 'RuleName') || ' retention period set to never expire.'
    else (r.Rules ->> 'RuleName') || ' retention period set to ' || (r.Rules -> 'Lifecycle' ->> 'DeleteAfterDays') || ' days.'
  end as reason,
  -- Additional Dimensions
  r.region,
  r.account_id
from
  all_plans as r;
+------------------------------------------------------------------------------------------------+--------+----------------------------------------------------------------+-----------+--------------+
| resource                                                                                       | status | reason                                                         | region    | account_id   |
+------------------------------------------------------------------------------------------------+--------+----------------------------------------------------------------+-----------+--------------+
| arn:aws:backup:us-east-1:1233444444:backup-plan:aws/efs/73d922fb-9312-3a70-99c3-e69367f9fdad | alarm  | aws/efs/automatic-backup-rule retention period set to 35 days. | us-east-1 | 1233444444 |
| arn:aws:backup:us-east-1:1233444444:backup-plan:b9bbb783-fcf4-40e5-b7f1-48eeaebaf8a6         | alarm  | DailyBackups retention period set to 35 days.                  | us-east-1 | 1233444444 |
| arn:aws:backup:us-east-1:1233444444:backup-plan:731ca791-9286-4144-b5ac-55c89f455e26         | alarm  | DailyBackups retention period set to 35 days.                  | us-east-1 | 1233444444 |
| arn:aws:backup:us-east-1:1233444444:backup-plan:731ca791-9286-4144-b5ac-55c89f455e26         | ok     | tets566 retention period set to never expire.                  | us-east-1 | 1233444444 |
| arn:aws:backup:us-east-1:1233444444:backup-plan:3f7c81e6-eff3-4d36-b9a3-fef3fffffa1e         | alarm  | DailyBackups retention period set to 35 days.                  | us-east-1 | 1233444444 |
+------------------------------------------------------------------------------------------------+--------+----------------------------------------------------------------+-----------+--------------+


```