### PR TITLE
DynamoDB table auto scaling should be enabled fails. Closes #31

### DIFF
--- a/query/dynamodb/dynamodb_table_auto_scaling_enabled.sql
+++ b/query/dynamodb/dynamodb_table_auto_scaling_enabled.sql
@@ -1,4 +1,4 @@
-with target_count as (
+with table_with_autocaling as (
   select
     t.resource_id as resource_id,
     count(t.resource_id) as count
@@ -24,4 +24,4 @@ select
   d.account_id
 from
   aws_dynamodb_table as d
-  left join target_count as t on concat('table/', d.name) = t.resource_id;
+  left join table_with_autocaling as t on concat('table/', d.name) = t.resource_id;

--- a/query/dynamodb/dynamodb_table_auto_scaling_enabled.sql
+++ b/query/dynamodb/dynamodb_table_auto_scaling_enabled.sql
@@ -1,22 +1,21 @@
-with scaling_target_count as (
+with target_count as (
   select
-    t.arn as arn,
-    count(target.resource_id) as count
+    t.resource_id as resource_id,
+    count(t.resource_id) as count
   from
-    aws_dynamodb_table as t
-    left join aws_appautoscaling_target as target on target.resource_id = concat('table/', t.name) and service_namespace = 'dynamodb'
-  group by t.arn
+    aws_appautoscaling_target as t where service_namespace = 'dynamodb'
+    group by t.resource_id
 )
 select
   -- Required Columns
   d.arn as resource,
   case
-    when t.count = 0 then 'alarm'
+    when t.resource_id is null then 'alarm'
     when t.count < 2 then 'alarm'
     else 'ok'
   end as status,
   case
-    when t.count = 0 then d.title || ' auto scaling not configured.'
+    when t.resource_id is null then d.title || ' autoscaling not enabled.'
     when t.count < 2 then d.title || ' auto scaling not enabled for both read and write capacity.'
     else d.title || ' autoscaling enabled for both read and write capacity.'
   end as reason,
@@ -24,5 +23,5 @@ select
   d.region,
   d.account_id
 from
-  aws_dynamodb_table d
-  left join scaling_target_count t on t.arn = d.arn;
+  aws_dynamodb_table as d
+  left join target_count as t on concat('table/', d.name) = t.resource_id;


### PR DESCRIPTION
### Checklist
- [ ] Issue(s) linked
```
> with target_count as (
  select
    t.resource_id as resource_id,
    count(t.resource_id) as count
  from
    aws_appautoscaling_target as t where service_namespace = 'dynamodb'
    group by t.resource_id
)
select
  -- Required Columns
  d.arn as resource,
  case
    when t.resource_id is null then 'alarm'
    when t.count < 2 then 'alarm'
    else 'ok'
  end as status,
  case
    when t.resource_id is null then d.title || ' autoscaling not enabled.'
    when t.count < 2 then d.title || ' auto scaling not enabled for both read and write capacity.'
    else d.title || ' autoscaling enabled for both read and write capacity.'
  end as reason,
  -- Additional Dimensions
  d.region,
  d.account_id
from
  aws_dynamodb_table as d
  left join target_count as t on concat('table/', d.name) = t.resource_id;

+-------------------------------------------------------------------+--------+-------------------------------------------------------------------------+-----------+--------------+
| resource                                                          | status | reason                                                                  | region    | account_id   |
+-------------------------------------------------------------------+--------+-------------------------------------------------------------------------+-----------+--------------+
| arn:aws:dynamodb:us-east-1:1234567891:table/no-autoscalling-tab | alarm  | no-autoscalling-tab autoscaling not enabled.                            | us-east-1 | 1234567891 |
| arn:aws:dynamodb:us-east-1:1234567891:table/test_table_target   | ok     | test_table_target autoscaling enabled for both read and write capacity. | us-east-1 | 1234567891 |
| arn:aws:dynamodb:us-east-1:1234567891:table/tets56              | ok     | tets56 autoscaling enabled for both read and write capacity.            | us-east-1 | 1234567891 |
| arn:aws:dynamodb:us-east-1:1234567891:table/tets67              | ok     | tets67 autoscaling enabled for both read and write capacity.            | us-east-1 | 1234567891 |
+-------------------------------------------------------------------+--------+-------------------------------------------------------------------------+-----------+--------------+
```