### PR TITLE
Control dax_cluster_encryption_at_rest_enabled failing due to un-supported region issue. Closes #321

### DIFF
--- a/query/dax/dax_cluster_encryption_at_rest_enabled.sql
+++ b/query/dax/dax_cluster_encryption_at_rest_enabled.sql
@@ -13,4 +13,8 @@ select
   region,
   account_id
 from
-  aws_dax_cluster;
+  aws_dax_cluster
+-- DAX is not supported in all the regions, for more information please check the below link
+-- https://aws.amazon.com/about-aws/whats-new/2018/04/amazon-dynamodb-accelerator-regional-expansion/
+where
+  region in('us-east-1','us-east-2','us-west-1','us-west-2','sa-east-1','eu-west-1','ap-southeast-1','ap-northeast-1','ap-southeast-2','ap-south-1');


### PR DESCRIPTION
…

### Checklist
- [ ] Issue(s) linked
```
select
  -- Required Columns
  arn as resource,
  case
    when sse_description ->> 'Status' = 'ENABLED' then 'ok'
    else 'alarm'
  end as status,
  case
    when sse_description ->> 'Status' = 'ENABLED' then title || ' encryption at rest enabled.'
    else title || ' encryption at rest not enabled.'
  end as reason,
  -- Additional Dimensions
  region,
  account_id
from
  aws_dax_cluster
-- DAX is not supported in all the regions, for more information please check the below link
-- https://aws.amazon.com/about-aws/whats-new/2018/04/amazon-dynamodb-accelerator-regional-expansion/
where
  region in('us-east-1','us-east-2','us-west-1','us-west-2','sa-east-1','eu-west-1','ap-southeast-1','ap-northeast-1','ap-southeast-2','ap-south-1');
+-------------------------------------------------+--------+----------------------------------------+-----------+--------------+
| resource                                        | status | reason                                 | region    | account_id   |
+-------------------------------------------------+--------+----------------------------------------+-----------+--------------+
| arn:aws:dax:us-east-1:1234567891:cache/tets   | ok     | tets encryption at rest enabled.       | us-east-1 | 1234567891 |
| arn:aws:dax:us-east-1:1234567891:cache/test   | ok     | test encryption at rest enabled.       | us-east-1 | 1234567891 |
| arn:aws:dax:us-east-1:1234567891:cache/test67 | alarm  | test67 encryption at rest not enabled. | us-east-1 | 1234567891 |
+-------------------------------------------------+--------+----------------------------------------+-----------+--------------+
````