### PR TITLE
Fix the `dynamodb_table_auto_scaling_enabled` query to correctly check if the tables have on demand capacity enabled closes #349

### DIFF
--- a/query/dynamodb/dynamodb_table_auto_scaling_enabled.sql
+++ b/query/dynamodb/dynamodb_table_auto_scaling_enabled.sql
@@ -16,7 +16,7 @@ select
     else 'ok'
   end as status,
   case
-    when d.billing_mode = 'PAY_PER_REQUEST' then d.title || ' On-demand mode enabled.'
+    when d.billing_mode = 'PAY_PER_REQUEST' then d.title || ' on-demand mode enabled.'
     when t.resource_id is null then d.title || ' autoscaling not enabled.'
     when t.count < 2 then d.title || ' auto scaling not enabled for both read and write capacity.'
     else d.title || ' autoscaling enabled for both read and write capacity.'

--- a/query/dynamodb/dynamodb_table_auto_scaling_enabled.sql
+++ b/query/dynamodb/dynamodb_table_auto_scaling_enabled.sql
@@ -10,11 +10,13 @@ select
   -- Required Columns
   d.arn as resource,
   case
+    when d.billing_mode = 'PAY_PER_REQUEST' then 'ok'
     when t.resource_id is null then 'alarm'
     when t.count < 2 then 'alarm'
     else 'ok'
   end as status,
   case
+    when d.billing_mode = 'PAY_PER_REQUEST' then d.title || ' On-demand mode enabled.'
     when t.resource_id is null then d.title || ' autoscaling not enabled.'
     when t.count < 2 then d.title || ' auto scaling not enabled for both read and write capacity.'
     else d.title || ' autoscaling enabled for both read and write capacity.'


### PR DESCRIPTION
### Checklist
- [ ] Issue(s) linked
