### PR TITLE
Add new FSBP controls. Closes #354

### DIFF
--- a/foundational_security/autoscaling.sp
+++ b/foundational_security/autoscaling.sp
@@ -8,7 +8,9 @@ benchmark "foundational_security_autoscaling" {
   title         = "Auto Scaling"
   documentation = file("./foundational_security/docs/foundational_security_autoscaling.md")
   children = [
-    control.foundational_security_autoscaling_1
+    control.foundational_security_autoscaling_1,
+    control.foundational_security_autoscaling_2,
+    control.foundational_security_autoscaling_5
   ]
   tags          = local.foundational_security_autoscaling_common_tags
 }
@@ -23,5 +25,31 @@ control "foundational_security_autoscaling_1" {
   tags = merge(local.foundational_security_autoscaling_common_tags, {
     foundational_security_item_id  = "autoscaling_1"
     foundational_security_category = "inventory"
+  })
+}
+
+control "foundational_security_autoscaling_2" {
+  title         = "2 Amazon EC2 Auto Scaling group should cover multiple Availability Zones"
+  description   = "This control checks whether an Auto Scaling group spans multiple Availability Zones. The control fails if an Auto Scaling group does not span multiple availability zones."
+  severity      = "medium"
+  sql           = query.autoscaling_group_multiple_az_configured.sql
+  documentation = file("./foundational_security/docs/foundational_security_autoscaling_2.md")
+
+  tags = merge(local.foundational_security_autoscaling_common_tags, {
+    foundational_security_item_id  = "autoscaling_2"
+    foundational_security_category = "high_availability"
+  })
+}
+
+control "foundational_security_autoscaling_5" {
+  title         = "5 Amazon EC2 instances launched using Auto Scaling group launch configurations should not have Public IP addresses"
+  description   = "This control checks whether an Auto Scaling groups associated launch configuration assigns a public IP address to the group’s instances."
+  severity      = "high"
+  sql           = query.autoscaling_launch_config_public_ip_disabled.sql
+  documentation = file("./foundational_security/docs/foundational_security_autoscaling_5.md")
+
+  tags = merge(local.foundational_security_autoscaling_common_tags, {
+    foundational_security_item_id  = "autoscaling_5"
+    foundational_security_category = "secure_network_configuration"
   })
 }

--- a/foundational_security/cloudfront.sp
+++ b/foundational_security/cloudfront.sp
@@ -13,7 +13,8 @@ benchmark "foundational_security_cloudfront" {
     control.foundational_security_cloudfront_3,
     control.foundational_security_cloudfront_4,
     control.foundational_security_cloudfront_5,
-    control.foundational_security_cloudfront_6
+    control.foundational_security_cloudfront_6,
+    control.foundational_security_cloudfront_7
   ]
   tags          = local.foundational_security_cloudfront_common_tags
 }
@@ -93,5 +94,18 @@ control "foundational_security_cloudfront_6" {
   tags = merge(local.foundational_security_cloudfront_common_tags, {
     foundational_security_item_id  = "cloudfront_6"
     foundational_security_category = "protective_services"
+  })
+}
+
+control "foundational_security_cloudfront_7" {
+  title         = "7 CloudFront distributions should use custom SSL/TLS certificates"
+  description   = "This control checks whether CloudFront distributions are using the default SSL/TLS certificate CloudFront provides. This control passes if the CloudFront distribution uses a custom SSL/TLS certificate. This control fails if the CloudFront distribution uses the default SSL/TLS certificate."
+  severity      = "medium"
+  sql           = query.cloudfront_distribution_use_custom_ssl_certificate.sql
+  documentation = file("./foundational_security/docs/foundational_security_cloudfront_7.md")
+
+  tags = merge(local.foundational_security_cloudfront_common_tags, {
+    foundational_security_item_id  = "cloudfront_6"
+    foundational_security_category = "encryption_of_data_in_transi"
   })
 }

--- a/foundational_security/cloudfront.sp
+++ b/foundational_security/cloudfront.sp
@@ -14,7 +14,8 @@ benchmark "foundational_security_cloudfront" {
     control.foundational_security_cloudfront_4,
     control.foundational_security_cloudfront_5,
     control.foundational_security_cloudfront_6,
-    control.foundational_security_cloudfront_7
+    control.foundational_security_cloudfront_7,
+    control.foundational_security_cloudfront_8
   ]
   tags          = local.foundational_security_cloudfront_common_tags
 }
@@ -105,7 +106,20 @@ control "foundational_security_cloudfront_7" {
   documentation = file("./foundational_security/docs/foundational_security_cloudfront_7.md")
 
   tags = merge(local.foundational_security_cloudfront_common_tags, {
-    foundational_security_item_id  = "cloudfront_6"
+    foundational_security_item_id  = "cloudfront_7"
     foundational_security_category = "encryption_of_data_in_transi"
+  })
+}
+
+control "foundational_security_cloudfront_8" {
+  title         = "8 CloudFront distributions should use SNI to serve HTTPS requests"
+  description   = "This control checks if Amazon CloudFront distributions are using a custom SSL/TLS certificate and are configured to use SNI to serve HTTPS requests. This control fails if a custom SSL/TLS certificate is associated but the SSL/TLS support method is a dedicated IP address."
+  severity      = "low"
+  sql           = query.cloudfront_distribution_sni_enabled.sql
+  documentation = file("./foundational_security/docs/foundational_security_cloudfront_8.md")
+
+  tags = merge(local.foundational_security_cloudfront_common_tags, {
+    foundational_security_item_id  = "cloudfront_8"
+    foundational_security_category = "secure_network_configuration"
   })
 }

--- a/foundational_security/codebuild.sp
+++ b/foundational_security/codebuild.sp
@@ -9,7 +9,9 @@ benchmark "foundational_security_codebuild" {
   documentation = file("./foundational_security/docs/foundational_security_codebuild.md")
   children = [
     control.foundational_security_codebuild_1,
-    control.foundational_security_codebuild_2
+    control.foundational_security_codebuild_2,
+    control.foundational_security_codebuild_4,
+    control.foundational_security_codebuild_5
   ]
   tags          = local.foundational_security_codebuild_common_tags
 }
@@ -37,5 +39,31 @@ control "foundational_security_codebuild_2" {
   tags = merge(local.foundational_security_codebuild_common_tags, {
     foundational_security_item_id  = "codebuild_2"
     foundational_security_category = "secure_development"
+  })
+}
+
+control "foundational_security_codebuild_4" {
+  title         = "4 CodeBuild project environments should have a logging configuration"
+  description   = "This control checks whether a CodeBuild project environment has at least one log option, either to S3 or CloudWatch logs enabled. This control fails if a CodeBuild project environment does not have at least one log option enabled."
+  severity      = "medium"
+  sql           = query.codebuild_project_logging_enabled.sql
+  documentation = file("./foundational_security/docs/foundational_security_codebuild_4.md")
+
+  tags = merge(local.foundational_security_codebuild_common_tags, {
+    foundational_security_item_id  = "codebuild_4"
+    foundational_security_category = "logging"
+  })
+}
+
+control "foundational_security_codebuild_5" {
+  title         = "5 CodeBuild project environments should not have privileged mode enabled"
+  description   = "This control checks if an AWS CodeBuild project environment has privileged mode enabled. This control fails when an AWS CodeBuild project environment has privileged mode enabled."
+  severity      = "high"
+  sql           = query.codebuild_project_environment_privileged_mode_disabled.sql
+  documentation = file("./foundational_security/docs/foundational_security_codebuild_5.md")
+
+  tags = merge(local.foundational_security_codebuild_common_tags, {
+    foundational_security_item_id  = "codebuild_5"
+    foundational_security_category = "secure_access_management"
   })
 }

--- a/foundational_security/docs/foundational_security_autoscaling_2.md
+++ b/foundational_security/docs/foundational_security_autoscaling_2.md
@@ -1,0 +1,9 @@
+## Description
+
+This control checks whether an Auto Scaling group spans multiple Availability Zones. The control fails if an Auto Scaling group does not span multiple availability zones.
+
+Amazon EC2 Auto Scaling groups can be configured to use multiple Availability Zones. An Auto Scaling group with a single Availability Zone is preferred in some use cases, such as batch-jobs or when inter-AZ transfer costs need to be kept to a minimum. However, an Auto Scaling group that does not span multiple Availability Zones will not launch instances in another Availability Zone to compensate if the configured single Availability Zone becomes unavailable.
+
+## Remediation
+
+For information on how to add Availability Zones to an existing auto scaling group, see [Availability zones](https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-add-availability-zone.html)in Amazon EC2 Auto Scaling user guide.

--- a/foundational_security/docs/foundational_security_autoscaling_5.md
+++ b/foundational_security/docs/foundational_security_autoscaling_5.md
@@ -1,0 +1,28 @@
+## Description
+
+This control checks whether an Auto Scaling groups associated launch configuration assigns a [public IP address](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#public-ip-addresses) to the group’s instances.
+
+Amazon EC2 instances in an autoscaling group launch configuration should not have an associated public IP address, except for in limited edge cases. Amazon EC2 instances should only be accessible from behind a load balancer instead of being directly exposed to the internet.
+
+This control passes if the associated launch configuration is configured to assign a public IP address. This control fails if the associated launch configuration is not configured to assign a public IP address.
+
+## Remediation
+
+An Auto Scaling group is associated with one launch configuration at a time. You cannot modify a launch configuration after you have create it. To change the launch configuration for an Auto Scaling group, use an existing launch configuration as the basis for a new launch configuration. Then, update the Auto Scaling group to use the new launch configuration as described in steps below.
+
+After you change the launch configuration for an Auto Scaling group, any new instances are launched with the new configuration options. Existing instances are not affected. To update existing instances, either terminate them so that they are replaced by your Auto Scaling group, or allow automatic scaling to gradually replace older instances with newer instances based on your termination policies.
+
+**To enable Elastic Load Balancing health checks**
+
+1. Open the [Amazon EC2 console](https://console.aws.amazon.com/ec2/).
+2. In the navigation pane, under `Auto Scaling`, choose `Launch Configurations`.
+3. Select the launch configuration and choose Actions, then Copy launch configuration. This sets up a new launch configuration with the same options as the original, but with "Copy" added to the name.
+4. On the `Create Launch Configuration` page, expand `Advanced details` under `Additional configuration - optional`.
+5. Under `IP address type`, choose `Do not assign a public IP address to any instances`.
+6. When you have finished, Choose `Create launch configuration`.
+7. On the navigation pane, under `Auto Scaling`, choose `Auto Scaling Groups`.
+8. Select the check box next to the Auto Scaling group.
+9. A split pane opens up in the bottom part of the page, showing information about the group that's selected.
+10. On the `Details` tab, choose `Launch configuration`, `Edit`.
+11. For `Launch configuration`, select the new launch configuration.
+12. When you have finished changing your launch configuration, choose `Update`.

--- a/foundational_security/docs/foundational_security_cloudfront_7.md
+++ b/foundational_security/docs/foundational_security_cloudfront_7.md
@@ -1,0 +1,9 @@
+## Description
+
+This control checks whether CloudFront distributions are using the default SSL/TLS certificate CloudFront provides. This control passes if the CloudFront distribution uses a custom SSL/TLS certificate. This control fails if the CloudFront distribution uses the default SSL/TLS certificate.
+
+Custom SSL/TLS allow your users to access content by using alternate domain names. You can store custom certificates in AWS Certificate Manager (recommended), or in IAM.
+
+## Remediation
+
+To add an alternate domain name using a custom SSL/TLS certificate for your CloudFront distributions, see [Adding an alternate domain name](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#CreatingCNAME) in the CloudFront Developer Guide.

--- a/foundational_security/docs/foundational_security_cloudfront_8.md
+++ b/foundational_security/docs/foundational_security_cloudfront_8.md
@@ -1,0 +1,9 @@
+## Description
+
+This control checks if Amazon CloudFront distributions are using a custom SSL/TLS certificate and are configured to use SNI to serve HTTPS requests. This control fails if a custom SSL/TLS certificate is associated but the SSL/TLS support method is a dedicated IP address.
+
+Server Name Indication (SNI) is an extension to the TLS protocol that is supported by browsers and clients released after 2010. If you configure CloudFront to serve HTTPS requests using SNI, CloudFront associates your alternate domain name with an IP address for each edge location. When a viewer submits an HTTPS request for your content, DNS routes the request to the IP address for the correct edge location. The IP address to your domain name is determined during the SSL/TLS handshake negotiation; the IP address isn't dedicated to your distribution.
+
+## Remediation
+
+To configure your CloudFront distributions to use SNI to serve HTTPS requests, see [Using SNI to Serve HTTPS Requests (works for Most Clients)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cnames-https-dedicated-ip-or-sni.html#cnames-https-sni) in the CloudFront Developer Guide.

--- a/foundational_security/docs/foundational_security_codebuild_4.md
+++ b/foundational_security/docs/foundational_security_codebuild_4.md
@@ -1,0 +1,9 @@
+## Description
+
+This control checks whether a CodeBuild project environment has at least one log option, either to S3 or CloudWatch logs enabled. This control fails if a CodeBuild project environment does not have at least one log option enabled.
+
+From a security perspective, logging is an important feature to enable for future forensics efforts in the case of any security incidents. Correlating anomalies in CodeBuild projects with threat detections can increase confidence in the accuracy of those threat detections.
+
+## Remediation
+
+For more information on how to configure CodeBuild project log settings, see [Create a build project (console)](https://docs.aws.amazon.com/codebuild/latest/userguide/create-project-console.html#create-project-console-logs) in the CodeBuild User Guide.

--- a/foundational_security/docs/foundational_security_codebuild_5.md
+++ b/foundational_security/docs/foundational_security_codebuild_5.md
@@ -1,0 +1,9 @@
+## Description
+
+This control checks if an AWS CodeBuild project environment has privileged mode enabled. This control fails when an AWS CodeBuild project environment has privileged mode enabled.
+
+By default, Docker containers do not allow access to any devices. Privileged mode grants a build project's Docker container access to all devices. Setting privilegedMode with value true enables running the Docker daemon inside a Docker container. The Docker daemon listens for Docker API requests and manages Docker objects such as images, containers, networks, and volumes. This parameter should only be set to true if the build project is used to build Docker images. Otherwise, this setting should be disabled to prevent unintended access to Docker APIs as well as the container’s underlying hardware as unintended access to privilegedMode may risk malicious tampering or deletion of critical resources.
+
+## Remediation
+
+For more information on how to configure CodeBuild project environment settings, see [Create a build project (console)](https://docs.aws.amazon.com/codebuild/latest/userguide/create-project-console.html#create-project-console-environment)in the CodeBuild User Guide

--- a/foundational_security/docs/foundational_security_ec2_21.md
+++ b/foundational_security/docs/foundational_security_ec2_21.md
@@ -1,0 +1,9 @@
+## Description
+
+This control checks if default ports for SSH/RDP ingress traffic for network access control lists (NACLs) is unrestricted. The rule fails if a NACL inbound entry allows a source CIDR block of '0.0.0.0/0' or '::/0' for ports 22 or 3389
+
+Access to remote server administration ports, such as port 22 (SSH) and port 3389 (RDP), should not be publicly accessible, as this may allow unintended access to resources within your VPC.
+
+## Remediation
+
+For more information about NACLs, see [Network ACLs](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html) in the VPC User Guide.

--- a/foundational_security/docs/foundational_security_ec2_22.md
+++ b/foundational_security/docs/foundational_security_ec2_22.md
@@ -1,0 +1,7 @@
+## Description
+
+This AWS control checks that security groups are attached to Amazon Elastic Compute Cloud (Amazon EC2) instances or to an elastic network interface. The control will fail if the security group is not associated with an Amazon EC2 instance or an elastic network interface.
+
+## Remediation
+
+To create, assign and delete security groups, see [Security groups](https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/working-with-security-groups.html#deleting-security-group) in Amazon EC2 user guide.

--- a/foundational_security/docs/foundational_security_lambda_5.md
+++ b/foundational_security/docs/foundational_security_lambda_5.md
@@ -12,5 +12,5 @@ Deploying resources across multiple Availability Zones is an AWS best practice t
 2. From the `Functions` page on the Lambda console choose a function.
 3. Choose `Configuration` and then choose VPC.
 4. Choose `Edit`.
-5. If the function was not originally connected to a VPC, select a VPC from the dropdown menu. If the function was not originally connected to a VPC, choose at least one security group to attach to the function
+5. If the function was not originally connected to a VPC, select a VPC from the dropdown menu. If the function was not originally connected to a VPC, choose at least one security group to attach to the function.
 6. Choose `Save`.

--- a/foundational_security/docs/foundational_security_lambda_5.md
+++ b/foundational_security/docs/foundational_security_lambda_5.md
@@ -1,0 +1,16 @@
+## Description
+
+This control checks if Lambda has more than one availability zone associated. The rule fails if only one availability zone is associated with Lambda.
+
+Deploying resources across multiple Availability Zones is an AWS best practice to ensure high availability within your architecture. Availability is a core pillar in the confidentiality, integrity, and availability triad security model. All Lambda functions should have a multi-Availability Zone deployment to ensure that a single zone of failure does not cause a total disruption of operations.
+
+## Remediation
+
+**To deploy a Lambda function in multiple Availability Zones through console:**
+
+1. Open the [AWS Lambda console](https://console.aws.amazon.com/lambda/.)
+2. From the `Functions` page on the Lambda console choose a function.
+3. Choose `Configuration` and then choose VPC.
+4. Choose `Edit`.
+5. If the function was not originally connected to a VPC, select a VPC from the dropdown menu. If the function was not originally connected to a VPC, choose at least one security group to attach to the function
+6. Choose `Save`.

--- a/foundational_security/docs/foundational_security_networkfirewall.md
+++ b/foundational_security/docs/foundational_security_networkfirewall.md
@@ -1,0 +1,3 @@
+## Overview
+
+This section contains recommendations for configuring Network Firewall resources and options.

--- a/foundational_security/docs/foundational_security_networkfirewall_6.md
+++ b/foundational_security/docs/foundational_security_networkfirewall_6.md
@@ -1,0 +1,14 @@
+## Description
+
+This control checks if a Stateless Network Firewall Rule Group contains rules. The rule will fail if there are no rules in a Stateless Network Firewall Rule Group.
+
+A rule group contains rules that define how your firewall processes traffic in your VPC. An empty stateless rule group when present in a firewall policy might give the impression that the rule group will process traffic. However, when the stateless rule group is empty, it does not process traffic.
+
+## Remediation
+
+**To update rule group and add a rule through console:**
+
+1. Sign in to the AWS Management Console and open the [Amazon VPC console](https://console.aws.amazon.com/vpc/).
+2. In the navigation pane, under `Network Firewall`, choose `Network Firewall rule groups`.
+3. In the `Network Firewall rule groups` page, choose the name of the firewall rule group that you want to edit. This takes you to the firewall rule groups details page.
+4. For stateless rule groups, choose `Edit Rules` to add rules to the rule group.

--- a/foundational_security/docs/foundational_security_rds_24.md
+++ b/foundational_security/docs/foundational_security_rds_24.md
@@ -1,0 +1,9 @@
+## Description
+
+This control checks whether an Amazon RDS database cluster has changed the admin username from its default value. This rule will fail if the admin username is set to the default value.
+
+When creating an Amazon RDS database, you should change the default admin username to a unique value. Default usernames are public knowledge and should be changed during RDS database creation. Changing the default usernames reduces the risk of unintended access.
+
+## Remediation
+
+For changing the admin username associated with the Amazon RDS database cluster, [create a new RDS database cluster](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.CreateInstance.html) and change the default admin username while creating the database.

--- a/foundational_security/docs/foundational_security_rds_25.md
+++ b/foundational_security/docs/foundational_security_rds_25.md
@@ -1,0 +1,9 @@
+## Description
+
+This control checks whether you've changed the administrative username for Amazon Relational Database Service (Amazon RDS) database instances from the default value. The control fails if the administrative username is set to the default value.
+
+Default administrative usernames on Amazon RDS databases are public knowledge. When creating an Amazon RDS database, you should change the default administrative username to a unique value to reduce the risk of unintended access.
+
+## Remediation
+
+To change the administrative username associated with an RDS database instance, first [create a new RDS database instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateDBInstance.html). Change the default administrative username while creating the database.

--- a/foundational_security/docs/foundational_security_redshift_8.md
+++ b/foundational_security/docs/foundational_security_redshift_8.md
@@ -1,0 +1,9 @@
+## Description
+
+This control checks whether a Amazon Redshift cluster has changed the admin username from its default value. This control will fail if the admin username for a Redshift cluster is set to awsuser.
+
+When creating a Redshift cluster, you should change the default admin username to a unique value. Default usernames are public knowledge and should be changed upon configuration. Changing the default usernames reduces the risk of unintended access.
+
+## Remediation
+
+You cannot change the admin username for your Amazon Redshift cluster after it is created. To create a new cluster, follow the instructions [here](https://docs.aws.amazon.com/redshift/latest/gsg/getting-started.html).

--- a/foundational_security/docs/foundational_security_s3_10.md
+++ b/foundational_security/docs/foundational_security_s3_10.md
@@ -1,0 +1,9 @@
+## Description
+
+This control checks if Amazon Simple Storage Service (Amazon S3) version enabled buckets have lifecycle policy configured. This rule fails if Amazon S3 lifecycle policy is not enabled.
+
+It is recommended to configure lifecycle rules on your Amazon S3 bucket as these rules help you define actions that you want Amazon S3 to take during an object's lifetime.
+
+## Remediation
+
+For more information on configuring lifecycle on an Amazon S3 bucket, see [Setting lifecycle configuration on a bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/how-to-set-lifecycle-configuration-intro.html)and [Managing your storage lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html).

--- a/foundational_security/docs/foundational_security_s3_9.md
+++ b/foundational_security/docs/foundational_security_s3_9.md
@@ -1,0 +1,15 @@
+## Description
+
+When logging is enabled, Amazon S3 delivers access logs for a source bucket to a chosen target bucket. The target bucket must be in the same AWS Region as the source bucket and must not have a default retention period configuration. The target logging bucket does not need to have logging enabled. This control passes if Server access logging is enabled.
+
+Server access logging provides detailed records of requests made to a bucket. Server access logs can assist in security and access audits. For more information, see Security Best Practices for Amazon S3: Enable Amazon S3 server access logging.
+
+## Remediation
+
+**To enable S3 bucket access logging**
+
+1. Sign in to the AWS Management Console and open the [Amazon S3 console](https://console.aws.amazon.com/s3/).
+2. Choose the bucket used for CloudTrail.
+3. Choose `Properties`.
+4. Choose `Server access logging`, then select `Edit`.
+5. Under `Server access logging` choose `Enable` then choose `Save changes`.

--- a/foundational_security/ec2.sp
+++ b/foundational_security/ec2.sp
@@ -21,7 +21,9 @@ benchmark "foundational_security_ec2" {
     control.foundational_security_ec2_16,
     control.foundational_security_ec2_17,
     control.foundational_security_ec2_18,
-    control.foundational_security_ec2_19
+    control.foundational_security_ec2_19,
+    control.foundational_security_ec2_21,
+    control.foundational_security_ec2_22
   ]
   tags          = local.foundational_security_ec2_common_tags
 }
@@ -205,5 +207,31 @@ control "foundational_security_ec2_19" {
   tags = merge(local.foundational_security_ec2_common_tags, {
     foundational_security_item_id  = "ec2_19"
     foundational_security_category = "security_group_configuration"
+  })
+}
+
+control "foundational_security_ec2_21" {
+  title         = "21 Network ACLs should not allow ingress from 0.0.0.0/0 to port 22 or port 3389"
+  description   = "This control checks if default ports for SSH/RDP ingress traffic for network access control lists (NACLs) is unrestricted. The rule fails if a NACL inbound entry allows a source CIDR block of '0.0.0.0/0' or '::/0' for ports 22 or 3389."
+  severity      = "medium"
+  sql           = query.vpc_network_acl_remote_administration.sql
+  documentation = file("./foundational_security/docs/foundational_security_ec2_21.md")
+
+  tags = merge(local.foundational_security_ec2_common_tags, {
+    foundational_security_item_id  = "ec2_21"
+    foundational_security_category = "secure_network_configuration"
+  })
+}
+
+control "foundational_security_ec2_22" {
+  title         = "22 Unused EC2 security groups should be removed"
+  description   = "This AWS control checks that security groups are attached to Amazon Elastic Compute Cloud (Amazon EC2) instances or to an elastic network interface. The control will fail if the security group is not associated with an Amazon EC2 instance or an elastic network interface."
+  severity      = "medium"
+  sql           = query.vpc_security_group_unsued.sql
+  documentation = file("./foundational_security/docs/foundational_security_ec2_22.md")
+
+  tags = merge(local.foundational_security_ec2_common_tags, {
+    foundational_security_item_id  = "ec2_22"
+    foundational_security_category = "inventory"
   })
 }

--- a/foundational_security/lambda.sp
+++ b/foundational_security/lambda.sp
@@ -10,7 +10,8 @@ benchmark "foundational_security_lambda" {
   children = [
     control.foundational_security_lambda_1,
     control.foundational_security_lambda_2,
-    control.foundational_security_lambda_4
+    control.foundational_security_lambda_4,
+    control.foundational_security_lambda_5
   ]
   tags          = local.foundational_security_lambda_common_tags
 }
@@ -24,7 +25,7 @@ control "foundational_security_lambda_1" {
 
   tags = merge(local.foundational_security_lambda_common_tags, {
     foundational_security_item_id  = "lambda_1"
-    #foundational_security_category = "secure_network_configuration"
+    foundational_security_category = "secure_network_configuration"
   })
 }
 
@@ -37,7 +38,7 @@ control "foundational_security_lambda_2" {
 
   tags = merge(local.foundational_security_lambda_common_tags, {
     foundational_security_item_id  = "lambda_2"
-    #foundational_security_category = "secure_development"
+    foundational_security_category = "secure_development"
   })
 }
 
@@ -51,5 +52,18 @@ control "foundational_security_lambda_4" {
   tags = merge(local.foundational_security_lambda_common_tags, {
     foundational_security_item_id  = "lambda_4"
     foundational_security_category = "logging"
+  })
+}
+
+control "foundational_security_lambda_5" {
+  title         = "5 VPC Lambda functions should operate in more than one Availability Zone"
+  description   = "This control checks if Lambda has more than one availability zone associated. The rule fails if only one availability zone is associated with Lambda."
+  severity      = "medium"
+  sql           = query.lambda_function_multiple_az_configured.sql
+  documentation = file("./foundational_security/docs/foundational_security_lambda_5.md")
+
+  tags = merge(local.foundational_security_lambda_common_tags, {
+    foundational_security_item_id  = "lambda_5"
+    foundational_security_category = "high_availability"
   })
 }

--- a/foundational_security/networkfirewall.sp
+++ b/foundational_security/networkfirewall.sp
@@ -1,0 +1,27 @@
+locals {
+  foundational_security_networkfirewall_common_tags = merge(local.foundational_security_common_tags, {
+    service = "networkfirewall"
+  })
+}
+
+benchmark "foundational_security_networkfirewall" {
+  title         = "Network Firewall"
+  documentation = file("./foundational_security/docs/foundational_security_networkfirewall.md")
+  children = [
+    control.foundational_security_networkfirewall_6
+  ]
+  tags          = local.foundational_security_networkfirewall_common_tags
+}
+
+control "foundational_security_networkfirewall_6" {
+  title         = "6 Stateless network firewall rule group should not be empty"
+  description   = "A rule group contains rules that define how your firewall processes traffic in your VPC. An empty stateless rule group when present in a firewall policy might give the impression that the rule group will process traffic. However, when the stateless rule group is empty, it does not process traffic."
+  severity      = "medium"
+  sql           = query.networkfirewall_stateless_rule_group_not_empty.sql
+  documentation = file("./foundational_security/docs/foundational_security_networkfirewall_6.md")
+
+  tags = merge(local.foundational_security_networkfirewall_common_tags, {
+    foundational_security_item_id  = "networkfirewall_1"
+    foundational_security_category = "secure_network_configuration"
+  })
+}

--- a/foundational_security/rds.sp
+++ b/foundational_security/rds.sp
@@ -29,7 +29,9 @@ benchmark "foundational_security_rds" {
     control.foundational_security_rds_20,
     control.foundational_security_rds_21,
     control.foundational_security_rds_22,
-    control.foundational_security_rds_23
+    control.foundational_security_rds_23,
+    control.foundational_security_rds_24,
+    control.foundational_security_rds_25
   ]
   tags          = local.foundational_security_rds_common_tags
 }
@@ -317,5 +319,31 @@ control "foundational_security_rds_23" {
   tags = merge(local.foundational_security_rds_common_tags, {
     foundational_security_item_id  = "rds_23"
     foundational_security_category = "secure_network_configuration"
+  })
+}
+
+control "foundational_security_rds_24" {
+  title         = "24 RDS database clusters should use a custom administrator username"
+  description   = "This control checks whether an Amazon RDS database cluster has changed the admin username from its default value. This rule will fail if the admin username is set to the default value."
+  severity      = "medium"
+  sql           = query.rds_db_cluster_no_default_admin_name.sql
+  documentation = file("./foundational_security/docs/foundational_security_rds_24.md")
+
+  tags = merge(local.foundational_security_rds_common_tags, {
+    foundational_security_item_id  = "rds_24"
+    foundational_security_category = "resource_configuration"
+  })
+}
+
+control "foundational_security_rds_25" {
+  title         = "25 RDS database instances should use a custom administrator username"
+  description   = "This control checks whether you've changed the administrative username for Amazon Relational Database Service (Amazon RDS) database instances from the default value. The control fails if the administrative username is set to the default value."
+  severity      = "medium"
+  sql           = query.rds_db_instance_no_default_admin_name.sql
+  documentation = file("./foundational_security/docs/foundational_security_rds_25.md")
+
+  tags = merge(local.foundational_security_rds_common_tags, {
+    foundational_security_item_id  = "rds_25"
+    foundational_security_category = "resource_configuration"
   })
 }

--- a/foundational_security/redshift.sp
+++ b/foundational_security/redshift.sp
@@ -13,7 +13,8 @@ benchmark "foundational_security_redshift" {
     control.foundational_security_redshift_3,
     control.foundational_security_redshift_4,
     control.foundational_security_redshift_6,
-    control.foundational_security_redshift_7
+    control.foundational_security_redshift_7,
+    control.foundational_security_redshift_8
   ]
   tags          = local.foundational_security_redshift_common_tags
 }
@@ -93,5 +94,18 @@ control "foundational_security_redshift_7" {
   tags = merge(local.foundational_security_redshift_common_tags, {
     foundational_security_item_id  = "redshift_7"
     foundational_security_category = "api_private_access"
+  })
+}
+
+control "foundational_security_redshift_8" {
+  title         = "8 Amazon Redshift clusters should not use the default Admin username"
+  description   = "This control checks whether a Amazon Redshift cluster has changed the admin username from its default value. This control will fail if the admin username for a Redshift cluster is set to awsuser."
+  severity      = "high"
+  sql           = query.redshift_cluster_no_default_admin_name.sql
+  documentation = file("./foundational_security/docs/foundational_security_redshift_8.md")
+
+  tags = merge(local.foundational_security_redshift_common_tags, {
+    foundational_security_item_id  = "redshift_8"
+    foundational_security_category = "resource_configuration"
   })
 }

--- a/foundational_security/s3.sp
+++ b/foundational_security/s3.sp
@@ -14,7 +14,9 @@ benchmark "foundational_security_s3" {
     control.foundational_security_s3_4,
     control.foundational_security_s3_5,
     control.foundational_security_s3_6,
-    control.foundational_security_s3_8
+    control.foundational_security_s3_8,
+    control.foundational_security_s3_9,
+    control.foundational_security_s3_10
   ]
   tags          = local.foundational_security_s3_common_tags
 }
@@ -107,5 +109,31 @@ control "foundational_security_s3_8" {
   tags = merge(local.foundational_security_s3_common_tags, {
     foundational_security_item_id  = "s3_8"
     foundational_security_category = "access_control"
+  })
+}
+
+control "foundational_security_s3_9" {
+  title         = "9 S3 bucket server access logging should be enabled"
+  description   = "When logging is enabled, Amazon S3 delivers access logs for a source bucket to a chosen target bucket. The target bucket must be in the same AWS Region as the source bucket and must not have a default retention period configuration."
+  severity      = "medium"
+  sql           = query.s3_bucket_public_access_blocked.sql
+  documentation = file("./foundational_security/docs/foundational_security_s3_9.md")
+
+  tags = merge(local.foundational_security_s3_common_tags, {
+    foundational_security_item_id  = "s3_9"
+    foundational_security_category = "logging"
+  })
+}
+
+control "foundational_security_s3_10" {
+  title         = "10 S3 buckets with versioning enabled should have lifecycle policies configured"
+  description   = "This control checks if Amazon Simple Storage Service (Amazon S3) version enabled buckets have lifecycle policy configured. This rule fails if Amazon S3 lifecycle policy is not enabled."
+  severity      = "medium"
+  sql           = query.s3_bucket_versioning_and_lifecycle_policy_enabled.sql
+  documentation = file("./foundational_security/docs/foundational_security_s3_10.md")
+
+  tags = merge(local.foundational_security_s3_common_tags, {
+    foundational_security_item_id  = "s3_10"
+    foundational_security_category = "logging"
   })
 }

--- a/mod.sp
+++ b/mod.sp
@@ -12,10 +12,10 @@ mod "aws_compliance" {
     description  = "Run individual configuration, compliance and security controls or full compliance benchmarks for CIS, PCI, NIST, HIPAA, RBI CSF, GDPR, SOC 2, Audit Manager Control Tower and AWS Foundational Security Best Practices controls across all your AWS accounts using Steampipe."
     image        = "/images/mods/turbot/aws-compliance-social-graphic.png"
   }
-  
+
   requires {
     plugin "aws" {
-      version = "0.45.0"
+      version = "0.54.0"
     }
   }
 }

--- a/query/autoscaling/autoscaling_group_multiple_az_configured.sql
+++ b/query/autoscaling/autoscaling_group_multiple_az_configured.sql
@@ -1,0 +1,13 @@
+select
+  -- Required Columns
+  autoscaling_group_arn as resource,
+  case
+    when jsonb_array_length(availability_zones) > 1 then 'ok'
+    else 'alarm'
+  end as status,
+  title || ' has ' || jsonb_array_length(availability_zones) || ' availability zone(s).' as reason,
+  -- Additional Dimensions
+  region,
+  account_id
+from
+  aws_ec2_autoscaling_group;

--- a/query/cloudfront/cloudfront_distribution_sni_enabled.sql
+++ b/query/cloudfront/cloudfront_distribution_sni_enabled.sql
@@ -1,0 +1,16 @@
+select
+  -- Required Columns
+  arn as resource,
+  case
+    when viewer_certificate ->> 'SSLSupportMethod' = 'sni-only' then 'ok'
+    else 'alarm'
+  end as status,
+  case
+    when viewer_certificate ->> 'SSLSupportMethod' = 'sni-only' then title || ' SNI enabled.'
+    else title || ' SNI disabled.'
+  end as reason,
+  -- Additional Dimensions
+  region,
+  account_id
+from
+  aws_cloudfront_distribution;

--- a/query/cloudfront/cloudfront_distribution_use_custom_ssl_certificate.sql
+++ b/query/cloudfront/cloudfront_distribution_use_custom_ssl_certificate.sql
@@ -1,0 +1,16 @@
+select
+  -- Required Columns
+  arn as resource,
+  case
+    when viewer_certificate ->> 'ACMCertificateArn' is not null and viewer_certificate ->> 'Certificate' is not null then 'ok'
+    else 'alarm'
+  end as status,
+  case
+    when viewer_certificate ->> 'ACMCertificateArn' is not null and viewer_certificate ->> 'Certificate' is not null then title || ' uses custom SSL certificate.'
+    else title || ' does not use custom SSL certificate.'
+  end as reason,
+  -- Additional Dimensions
+  region,
+  account_id
+from
+  aws_cloudfront_distribution;

--- a/query/codebuild/codebuild_project_environment_privileged_mode_disabled.sql
+++ b/query/codebuild/codebuild_project_environment_privileged_mode_disabled.sql
@@ -1,0 +1,16 @@
+select
+  -- Required Columns
+  arn as resource,
+  case
+    when environment ->> 'PrivilegedMode' = 'true' then 'alarm'
+    else 'ok'
+  end as status,
+  case
+    when environment ->> 'PrivilegedMode' = 'true' then title || ' environment privileged mode enabled.'
+    else title || ' environment privileged mode disabled.'
+  end as reason,
+  -- Additional Dimensions
+  region,
+  account_id
+from
+  aws_codebuild_project;

--- a/query/codebuild/codebuild_project_logging_enabled.sql
+++ b/query/codebuild/codebuild_project_logging_enabled.sql
@@ -1,0 +1,16 @@
+select
+  -- Required Columns
+  arn as resource,
+  case
+    when logs_config -> 'CloudWatchLogs' ->> 'Status' = 'ENABLED' or logs_config -> 'S3Logs' ->> 'Status' = 'ENABLED' then 'ok'
+    else 'alarm'
+  end as status,
+  case
+    when logs_config -> 'CloudWatchLogs' ->> 'Status' = 'ENABLED' or logs_config -> 'S3Logs' ->> 'Status' = 'ENABLED' then title || ' logging enabled.'
+    else title || ' logging disabled.'
+  end as reason,
+  -- Additional Dimensions
+  region,
+  account_id
+from
+  aws_codebuild_project;

--- a/query/lambda/lambda_function_multiple_az_configured.sql
+++ b/query/lambda/lambda_function_multiple_az_configured.sql
@@ -1,0 +1,17 @@
+select
+  -- Required Columns
+  arn as resource,
+  case
+    when vpc_subnet_ids is null then 'alarm'
+    when jsonb_array_length(vpc_subnet_ids) > 1 then 'ok'
+    else 'alarm'
+  end as status,
+  case
+    when vpc_subnet_ids is null then title || ' is not in VPC.'
+    else title || ' has ' || jsonb_array_length(vpc_subnet_ids) || ' availability zone(s).'
+  end as reason,
+  -- Additional Dimensions
+  region,
+  account_id
+from
+  aws_lambda_function;

--- a/query/networkfirewall/networkfirewall_stateless_rule_group_not_empty.sql
+++ b/query/networkfirewall/networkfirewall_stateless_rule_group_not_empty.sql
@@ -1,0 +1,17 @@
+select
+  -- Required Columns
+  arn as resource,
+  case
+    when type = 'STATEFUL' then 'skip'
+    when jsonb_array_length(rules_source -> 'StatelessRulesAndCustomActions' -> 'StatelessRules') > 0 then 'ok'
+    else 'alarm'
+  end as status,
+  case
+    when type = 'STATEFUL' then title || ' is a stateful rule group.'
+    else title || ' has ' || jsonb_array_length(rules_source -> 'StatelessRulesAndCustomActions' -> 'StatelessRules') || ' rule(s).'
+  end as reason,
+  -- Additional Dimensions
+  region,
+  account_id
+from
+  aws_networkfirewall_rule_group;

--- a/query/rds/rds_db_cluster_no_default_admin_name.sql
+++ b/query/rds/rds_db_cluster_no_default_admin_name.sql
@@ -1,0 +1,16 @@
+select
+  -- Required Columns
+  arn as resource,
+  case
+    when master_user_name in ('admin','postgres') then 'alarm'
+    else 'ok'
+  end status,
+  case
+    when master_user_name in ('admin','postgres') then title || ' using default master user name.'
+    else title || ' not using default master user name.'
+  end reason,
+  -- Additional Dimensions
+  region,
+  account_id
+from
+  aws_rds_db_cluster;

--- a/query/rds/rds_db_instance_no_default_admin_name.sql
+++ b/query/rds/rds_db_instance_no_default_admin_name.sql
@@ -1,0 +1,16 @@
+select
+  -- Required Columns
+  arn as resource,
+  case
+    when master_user_name in ('admin','postgres') then 'alarm'
+    else 'ok'
+  end status,
+  case
+    when master_user_name in ('admin','postgres') then title || ' using default master user name.'
+    else title || ' not using default master user name.'
+  end reason,
+  -- Additional Dimensions
+  region,
+  account_id
+from
+  aws_rds_db_instance;

--- a/query/redshift/redshift_cluster_no_default_admin_name.sql
+++ b/query/redshift/redshift_cluster_no_default_admin_name.sql
@@ -1,0 +1,16 @@
+select
+  -- Required Columns
+  arn as resource,
+  case
+    when master_username = 'awsuser' then 'alarm'
+    else 'ok'
+  end status,
+  case
+    when master_username = 'awsuser' then title || ' using default master user name.'
+    else title || ' not using default master user name.'
+  end reason,
+  -- Additional Dimensions
+  region,
+  account_id
+from
+  aws_redshift_cluster;

--- a/query/s3/s3_bucket_versioning_and_lifecycle_policy_enabled.sql
+++ b/query/s3/s3_bucket_versioning_and_lifecycle_policy_enabled.sql
@@ -1,0 +1,28 @@
+with lifecycle_rules_enabled as (
+  select
+    arn
+  from
+    aws_s3_bucket,
+    jsonb_array_elements(lifecycle_rules) as r
+  where
+    r ->> 'Status' = 'Enabled'
+)
+select
+  -- Required Columns
+  b.arn as resource,
+  case
+    when not versioning_enabled then 'alarm'
+    when versioning_enabled and r.arn is not null then 'ok'
+    else 'alarm'
+  end status,
+  case
+    when not versioning_enabled then name || ' versioning diabled.'
+    when versioning_enabled and r.arn is not null then ' lifecycle policy configured'
+    else name || '  lifecycle policy not configured.'
+  end reason,
+  -- Additional Dimensions
+  region,
+  account_id
+from
+  aws_s3_bucket as b
+  left join lifecycle_rules_enabled as r on r.arn = b.arn;

--- a/query/vpc/vpc_security_group_unsued.sql
+++ b/query/vpc/vpc_security_group_unsued.sql
@@ -1,0 +1,33 @@
+with associated_sg as (
+  select
+    sg ->> 'GroupId' as secgrp_id
+  from
+    aws_ec2_network_interface,
+    jsonb_array_elements(groups) as sg
+    group by sg ->> 'GroupId'
+  union
+    select
+    sg ->> 'GroupId' as secgrp_id
+  from
+    aws_ec2_instance,
+    jsonb_array_elements(security_groups) as sg
+    group by sg ->> 'GroupId'
+
+)
+select
+  -- Required Columns
+  distinct s.arn as resource,
+  case
+    when a.secgrp_id is not null then 'ok'
+    else 'alarm'
+  end as status,
+  case
+    when a.secgrp_id is not null then s.title || ' is in use.'
+    else s.title || ' not in use.'
+  end as reason,
+  -- Additional Dimensions
+  s.region,
+  s.account_id
+from
+  aws_vpc_security_group as s
+  left join associated_sg as a on s.group_id = a.secgrp_id;


### PR DESCRIPTION
Controls Added
- [AutoScaling.2] Amazon EC2 Auto Scaling group should cover multiple Availability Zones
- [AutoScaling.5] Amazon EC2 instances launched using Auto Scaling group launch configurations should not have Public IP addresses
- [CloudFront.7] CloudFront distributions should use custom SSL/TLS certificates
- [CloudFront.8] CloudFront distributions should use SNI to serve HTTPS requests
- [CodeBuild.4] CodeBuild project environments should have a logging configuration
- [CodeBuild.5] CodeBuild project environments should not have privileged mode enabled
- [EC2.21] Network ACLs should not allow ingress from 0.0.0.0/0 to port 22 or port 3389
- [EC2.22] Unused EC2 security groups should be removed
- [Lambda.5] VPC Lambda functions should operate in more than one Availability Zone
- [NetworkFirewall.6] Stateless network firewall rule group should not be empty
- [RDS.24] RDS database clusters should use a custom administrator username
- [RDS.25] RDS database instances should use a custom administrator username
- [Redshift.8] Amazon Redshift clusters should not use the default Admin username
- [S3.9] S3 bucket server access logging should be enabled
- [S3.10] S3 buckets with versioning enabled should have lifecycle policies configured