### PR TITLE
Handle Lambda custom runtimes & fix lambda queries

### DIFF
--- a/query/lambda/lambda_function_concurrent_execution_limit_configured.sql
+++ b/query/lambda/lambda_function_concurrent_execution_limit_configured.sql
@@ -13,4 +13,4 @@ select
   region,
   account_id
 from
-  aws_lambda_function;
+  "aws_lambda_function";

--- a/query/lambda/lambda_function_dead_letter_queue_configured.sql
+++ b/query/lambda/lambda_function_dead_letter_queue_configured.sql
@@ -13,4 +13,4 @@ select
   region,
   account_id
 from
-  aws_lambda_function;
+  "aws_lambda_function";

--- a/query/lambda/lambda_function_in_vpc.sql
+++ b/query/lambda/lambda_function_in_vpc.sql
@@ -2,8 +2,11 @@ select
   -- Required Columns
   arn as resource,
   case
-    when vpc_id is null then 'alarm'
-    else 'ok'
+    when vpc_id is null then 'ok'
+    else case
+      when jsonb_array_length(vpc_subnet_ids) > 1 then 'ok'
+      else 'alarm'
+    end
   end status,
   case
     when vpc_id is null then title || ' is not in VPC.'

--- a/query/lambda/lambda_function_in_vpc.sql
+++ b/query/lambda/lambda_function_in_vpc.sql
@@ -13,4 +13,4 @@ select
   region,
   account_id
 from
-  aws_lambda_function;
+  "aws_lambda_function";

--- a/query/lambda/lambda_function_multiple_az_configured.sql
+++ b/query/lambda/lambda_function_multiple_az_configured.sql
@@ -14,4 +14,4 @@ select
   region,
   account_id
 from
-  aws_lambda_function;
+  "aws_lambda_function";

--- a/query/lambda/lambda_function_multiple_az_configured.sql
+++ b/query/lambda/lambda_function_multiple_az_configured.sql
@@ -1,10 +1,18 @@
+
 select
   -- Required Columns
   arn as resource,
   case
-    when vpc_subnet_ids is null then 'alarm'
-    when jsonb_array_length(vpc_subnet_ids) > 1 then 'ok'
+    when vpc_id is null then 'ok'
+    else case    
+      when 
+      (select count(distinct availability_zone_id) from aws_vpc_subnet 
+        where 
+          subnet_id in (select jsonb_array_elements_text(vpc_subnet_ids) )  
+      ) >= 2
+      then 'ok'
     else 'alarm'
+    end
   end as status,
   case
     when vpc_subnet_ids is null then title || ' is not in VPC.'
@@ -15,3 +23,4 @@ select
   account_id
 from
   "aws_lambda_function";
+  

--- a/query/lambda/lambda_function_restrict_public_access.sql
+++ b/query/lambda/lambda_function_restrict_public_access.sql
@@ -22,4 +22,4 @@ select
   region,
   account_id
 from
-  aws_lambda_function;
+  "aws_lambda_function";

--- a/query/lambda/lambda_function_use_latest_runtime.sql
+++ b/query/lambda/lambda_function_use_latest_runtime.sql
@@ -2,11 +2,12 @@ select
   -- Required Columns
   arn as resource,
   case
-    when runtime in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then 'ok'
+    when (( runtime in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') ) OR runtime is NULL) then 'ok'
     else 'alarm'
   end as status,
   case
     when runtime in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then title || ' uses latest runtime - ' || runtime || '.'
+    when runtime is NULL then title || ' uses custom runtime.'
     else title || ' uses ' || runtime || ' which is not the latest version.'
   end as reason,
   -- Additional Dimensions

--- a/query/lambda/lambda_function_use_latest_runtime.sql
+++ b/query/lambda/lambda_function_use_latest_runtime.sql
@@ -2,16 +2,17 @@ select
   -- Required Columns
   arn as resource,
   case
-    when (( runtime in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') ) OR runtime is NULL) then 'ok'
+    when runtime in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then 'ok'
     else 'alarm'
   end as status,
   case
     when runtime in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then title || ' uses latest runtime - ' || runtime || '.'
-    when runtime is NULL then title || ' uses custom runtime.'
     else title || ' uses ' || runtime || ' which is not the latest version.'
   end as reason,
   -- Additional Dimensions
   region,
-  account_id
+  account_id,
+  packagetype
 from
-  "aws_lambda_function";
+  "aws_lambda_function"
+where packagetype = 'Zip';

--- a/query/lambda/lambda_function_use_latest_runtime.sql
+++ b/query/lambda/lambda_function_use_latest_runtime.sql
@@ -12,7 +12,7 @@ select
   -- Additional Dimensions
   region,
   account_id,
-  packagetype
+  package_type
 from
   "aws_lambda_function"
-where packagetype = 'Zip';
+where package_type = 'Zip';

--- a/query/lambda/lambda_function_use_latest_runtime.sql
+++ b/query/lambda/lambda_function_use_latest_runtime.sql
@@ -13,4 +13,4 @@ select
   region,
   account_id
 from
-  aws_lambda_function;
+  "aws_lambda_function";


### PR DESCRIPTION
Closes #370 

- Added quotes for aws_lambda_function table in query/lambda/*
- Handled Lambda custom runtimes in lambda queries. 
   Custom runtimes have a null value as runtime

Possible improvement: Use package type to determine custom runtime.
PackageType is "Image" for custom runtimes
