### PR TITLE
Aurora - Deletion protection is at cluster level and not DB instance level - foundational security logic should be updated Closes #400

### DIFF
--- a/query/rds/rds_db_instance_deletion_protection_enabled.sql
+++ b/query/rds/rds_db_instance_deletion_protection_enabled.sql
@@ -2,10 +2,12 @@ select
   -- Required Columns
   arn as resource,
   case
+    when engine like any ( ARRAY['aurora%', 'docdb', 'neptune']) then 'skip'
     when deletion_protection then 'ok'
     else 'alarm'
   end status,
   case
+    when engine like any ( ARRAY['aurora%', 'docdb', 'neptune']) then title || ' is of ' || engine || ' cluster, deletion protection is set at cluster level.'
     when deletion_protection then title || ' deletion protection enabled.'
     else title || ' deletion protection not enabled.'
   end reason,


### PR DESCRIPTION

### Checklist
- [ ] Issue(s) linked
```
select
  -- Required Columns
  arn as resource,
  case
    when engine like any ( ARRAY['aurora%', 'docdb', 'neptune']) then 'skip'
    when deletion_protection then 'ok'
    else 'alarm'
  end status,
  case
    when engine like any ( ARRAY['aurora%', 'docdb', 'neptune']) then title || ' is of ' || engine || ' cluster, deletion protection is set at cluster level.'
    when deletion_protection then title || ' deletion protection enabled.'
    else title || ' deletion protection not enabled.'
  end reason,
  -- Additional Dimensions
  region,
  account_id
from
  aws_rds_db_instance;
+-------------------------------------------------------------------+--------+-----------------------------------------------------------------------------------------------------+------------+--------------+
| resource                                                          | status | reason                                                                                              | region     | account_id   |
+-------------------------------------------------------------------+--------+-----------------------------------------------------------------------------------------------------+------------+--------------+
| arn:aws:rds:ap-south-1:123456768249:db:mysqldatabase-1            | alarm  | mysqldatabase-1 deletion protection not enabled.                                                    | ap-south-1 | 123456768249 |
| arn:aws:rds:ap-south-1:123456768249:db:auroracluster-1-instance-1 | skip   | auroracluster-1-instance-1 is of aurora-mysql cluster, deletion protection is set at cluster level. | ap-south-1 | 123456768249 |
| arn:aws:rds:us-east-1:123456768249:db:docdb-2022-05-30-10-11-42   | skip   | docdb-2022-05-30-10-11-42 is of docdb cluster, deletion protection is set at cluster level.         | us-east-1  | 123456768249 |
+-------------------------------------------------------------------+--------+-----------------------------------------------------------------------------------------------------+------------+--------------+
```
