### PR TITLE
Filter out opted out regions in config check

### DIFF
--- a/query/config/config_enabled_all_regions.sql
+++ b/query/config/config_enabled_all_regions.sql
@@ -49,4 +49,6 @@ from
   global_recorders as g,
   aws_region as a
   left join aws_config_configuration_recorder as r
-    on r.account_id = a.account_id and r.region = a.name;
+    on r.account_id = a.account_id and r.region = a.name
+where
+  a.opt_in_status != 'not-opted-in';


### PR DESCRIPTION
This PR updates the "AWS Config Enabled in all regions" query to filter out regions that are opted out. Opted out regions can not be accessed in any way so missing config resources in those regions should not be reported as an error.