### PR TITLE
Ignore KMS keys that are pending deletion in rotation check

### DIFF
--- a/query/kms/kms_cmk_rotation_enabled.sql
+++ b/query/kms/kms_cmk_rotation_enabled.sql
@@ -4,12 +4,14 @@ select
   case
     when origin = 'EXTERNAL' then 'skip'
     when key_state = 'PendingDeletion' then 'skip'
+    when key_state = 'Disabled' then 'skip'
     when not key_rotation_enabled then 'alarm'
     else 'ok'
   end as status,
   case
     when origin = 'EXTERNAL' then title || ' has imported key material.'
     when key_state = 'PendingDeletion' then title || ' is pending deletion.'
+    when key_state = 'Disabled' then title || ' is disabled.'
     when not key_rotation_enabled then title || ' key rotation disabled.'
     else title || ' key rotation enabled.'
   end as reason,

--- a/query/kms/kms_cmk_rotation_enabled.sql
+++ b/query/kms/kms_cmk_rotation_enabled.sql
@@ -3,11 +3,13 @@ select
   arn as resource,
   case
     when origin = 'EXTERNAL' then 'skip'
+    when key_state = 'PendingDeletion' then 'skip'
     when not key_rotation_enabled then 'alarm'
     else 'ok'
   end as status,
   case
     when origin = 'EXTERNAL' then title || ' has imported key material.'
+    when key_state = 'PendingDeletion' then title || ' is pending deletion.'
     when not key_rotation_enabled then title || ' key rotation disabled.'
     else title || ' key rotation enabled.'
   end as reason,


### PR DESCRIPTION
### Benchmark where identified

- CIS v1.4.0

### Description

This updates the KMS CMK rotation enabled query to skip any KMS keys that are in the `Pending Deletion` state. These keys are marked for deletion, and thus it doesn't matter if rotation is enabled or not, so best to skip them to keep the report clean.

If the key is ever restored and put out of pending deletion, then the state will change and should show up in the report the next time it runs.

### Sample output

(data has been sanitized to mask real IDs)

```
| + 3.8 Ensure rotation for customer created CMKs is enabled ............................................................................ 0 /   6 [=         ]
| | |
| | OK   : KEY_ID key rotation enabled. ................................................................. us-east-1 000000000000
| | OK   : KEY_ID key rotation enabled. ................................................................. us-east-1 000000000000
| | OK   : KEY_ID key rotation enabled. ................................................................. us-east-1 000000000000
| | SKIP : KEY_ID is pending deletion. .................................................................. us-east-1 000000000000
| | SKIP : KEY_ID is pending deletion. .................................................................. us-east-1 000000000000
| | SKIP : KEY_ID is pending deletion. .................................................................. us-east-1 000000000000
|
```