### PR TITLE
Fix error from VPC flow logs query

### DIFF
--- a/query/vpc/vpc_flow_logs_enabled.sql
+++ b/query/vpc/vpc_flow_logs_enabled.sql
@@ -1,6 +1,6 @@
 select
   -- Required columns
-  distinct arn,
+  distinct arn as resource,
   case
     when v.account_id <> v.owner_id then 'skip'
     when f.resource_id is not null then 'ok'


### PR DESCRIPTION
### Benchmark where identified

- CIS v1.4.0

### Description

I started getting the following error with the latest `main` when running `steampipe check`:

```
| + 3.9 Ensure VPC flow logging is enabled in all VPCs .................................................................................. 1 /   1 [=         ]
| |
| | ERROR: control result is missing required column: [resource]
|
```

This PR is an attempt to fix that.

### Sample output

(data has been sanitized to mask real IDs)

```
| + 3.9 Ensure VPC flow logging is enabled in all VPCs .................................................................................. 0 /   1 [=         ]
| | |
| | OK   : VPC_ID flow logging enabled. ................................................................................ us-east-1 0000000000

```


### Relevant info

Steampipe version v0.15.0
AWS plugin version v0.68.0