### PR TITLE
 Update foundational_security_lambda_2 control to use latest runtimes Closes #495

### DIFF
--- a/query/lambda/lambda_function_use_latest_runtime.sql
+++ b/query/lambda/lambda_function_use_latest_runtime.sql
@@ -1,10 +1,9 @@
-
 select
   -- Required Columns
   arn as resource,
   case
     when package_type <> 'Zip' then 'skip'
-    when runtime in ('nodejs16.x',  'nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.9', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'java8.al2', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1', 'dotnet6') then 'ok'
+    when runtime in ('nodejs16.x', 'nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.9', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'java8.al2', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1', 'dotnet6') then 'ok'
     else 'alarm'
   end as status,
   case

--- a/query/lambda/lambda_function_use_latest_runtime.sql
+++ b/query/lambda/lambda_function_use_latest_runtime.sql
@@ -1,9 +1,10 @@
+
 select
   -- Required Columns
   arn as resource,
   case
     when package_type <> 'Zip' then 'skip'
-    when runtime in ('nodejs16.x', 'nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.9', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'java8.al2', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1', 'dotnet6') then 'ok'
+    when runtime in ('nodejs16.x',  'nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.9', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'java8.al2', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1', 'dotnet6') then 'ok'
     else 'alarm'
   end as status,
   case

--- a/query/lambda/lambda_function_use_latest_runtime.sql
+++ b/query/lambda/lambda_function_use_latest_runtime.sql
@@ -3,12 +3,12 @@ select
   arn as resource,
   case
     when package_type <> 'Zip' then 'skip'
-    when runtime in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then 'ok'
+    when runtime in ('nodejs16.x', 'nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.9', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'java8.al2', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1', 'dotnet6') then 'ok'
     else 'alarm'
   end as status,
   case
     when package_type <> 'Zip' then title || ' package type is ' || package_type || '.'
-    when runtime in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then title || ' uses latest runtime - ' || runtime || '.'
+    when runtime in ('nodejs16.x', 'nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.9', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'java8.al2', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1', 'dotnet6') then title || ' uses latest runtime - ' || runtime || '.'
     else title || ' uses ' || runtime || ' which is not the latest version.'
   end as reason,
   -- Additional Dimensions


### PR DESCRIPTION
### Checklist
- [x] Issue(s) linked

```
+ 2 Lambda functions should use latest runtimes ..................................................................... 2 / 8 [==========]
  | 
  ALARM: cloud9-AppTwo-funcone-W408ZRFMCP4Q uses nodejs6.10 which is not the latest version. .................... eu-west-1 533793682495
  ALARM: cloud9-TestApp-lambdaone-A71A4OKVLX6D uses nodejs6.10 which is not the latest version. ................. eu-west-1 533793682495
  OK   : test1 uses latest runtime - nodejs14.x. ............................................................... ap-south-1 111111111111
  OK   : graviton2 uses latest runtime - nodejs14.x. ............................................................ us-east-2 111111111111
  OK   : tetest0vpc uses latest runtime - nodejs14.x. ........................................................... us-east-2 111111111111
  OK   : test-delete uses latest runtime - **nodejs16.x.** .......................................................... us-east-1 111111111111
  OK   : new-test uses latest runtime - **python3.9.** .............................................................. us-east-1 111111111111
  OK   : tets uses latest runtime - nodejs16.x. ................................................................. us-east-1 111111111111
```