### PR TITLE
Add additional ACL Conditions for Public Buckets

### DIFF
--- a/query/s3/s3_bucket_restrict_public_read_access.sql
+++ b/query/s3/s3_bucket_restrict_public_read_access.sql
@@ -5,9 +5,13 @@ with data as (
     aws_s3_bucket,
     jsonb_array_elements(acl -> 'Grants') as grants
   where
-    grants -> 'Grantee' ->> 'URI' = 'http://acs.amazonaws.com/groups/global/AllUsers'
+    (
+      grants -> 'Grantee' ->> 'URI' = 'http://acs.amazonaws.com/groups/global/AllUsers'
+      or grants -> 'Grantee' ->> 'URI' = 'http://acs.amazonaws.com/groups/global/AuthenticatedUsers'
+    )
     and (
       grants ->> 'Permission' = 'FULL_CONTROL'
+      or grants ->> 'Permission' = 'READ'
       or grants ->> 'Permission' = 'READ_ACP'
     )
   )

--- a/query/s3/s3_bucket_restrict_public_write_access.sql
+++ b/query/s3/s3_bucket_restrict_public_write_access.sql
@@ -9,6 +9,7 @@ with data as (
     and (
       grants ->> 'Permission' = 'FULL_CONTROL'
       or grants ->> 'Permission' = 'WRITE_ACP'
+      or grants ->> 'Permission' = 'WRITE'
     )
   )
 select

--- a/query/s3/s3_bucket_restrict_public_write_access.sql
+++ b/query/s3/s3_bucket_restrict_public_write_access.sql
@@ -5,7 +5,10 @@ with data as (
     aws_s3_bucket,
     jsonb_array_elements(acl -> 'Grants') as grants
   where
-    grants -> 'Grantee' ->> 'URI' = 'http://acs.amazonaws.com/groups/global/AllUsers'
+    (
+      grants -> 'Grantee' ->> 'URI' = 'http://acs.amazonaws.com/groups/global/AllUsers'
+      or grants -> 'Grantee' ->> 'URI' = 'http://acs.amazonaws.com/groups/global/AuthenticatedUsers'
+    )
     and (
       grants ->> 'Permission' = 'FULL_CONTROL'
       or grants ->> 'Permission' = 'WRITE_ACP'


### PR DESCRIPTION
The Grant http://acs.amazonaws.com/groups/global/AuthenticatedUsers represents _all_ AWS Customers and is another form of "Public Bucket".
Additionally the WRITE and READ acls were missing from the `query/s3/s3_bucket_restrict_public_write_access.sql` and `query/s3/s3_bucket_restrict_public_read_access.sql `queries
