### PR TITLE
Add docdb_cluster_instance_logging_enabled control to other checks

### DIFF
--- a/conformance_pack/docdb.sp
+++ b/conformance_pack/docdb.sp
@@ -1,0 +1,36 @@
+locals {
+  conformance_pack_docdb_common_tags = merge(local.aws_compliance_common_tags, {
+    service = "AWS/DocumentDB"
+  })
+}
+
+control "docdb_cluster_instance_logging_enabled" {
+  title       = "DocumentDB instance logging should be enabled"
+  description = "To help with logging and monitoring within your environment, ensure Amazon DocumentDB instance logging is enabled."
+  query       = query.docdb_cluster_instance_logging_enabled
+
+  tags = merge(local.conformance_pack_docdb_common_tags, {
+    other_checks = "true"
+  })
+}
+
+query "docdb_cluster_instance_logging_enabled" {
+  sql = <<-EOQ
+    select
+      db_instance_arn as resource,
+      engine,
+      case
+        when engine like 'docdb' and enabled_cloudwatch_logs_exports ?& array ['error', 'slowquery'] then 'ok'
+        else 'alarm'
+      end as status,
+      case
+        when engine like 'docdb' and enabled_cloudwatch_logs_exports ?& array ['error', 'slowquery']
+        then title || ' ' || engine || ' logging enabled.'
+        else title || ' logging not enabled.'
+      end as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      aws_docdb_cluster_instance;
+  EOQ
+}

--- a/conformance_pack/rds.sp
+++ b/conformance_pack/rds.sp
@@ -572,26 +572,7 @@ query "rds_db_instance_logging_enabled" {
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}
     from
-      aws_rds_db_instance
-
-    union
-    
-    select
-      db_instance_arn as resource,
-      engine,
-      case
-        when engine like 'docdb' and enabled_cloudwatch_logs_exports ?& array ['error', 'slowquery'] then 'ok'
-        else 'alarm'
-      end as status,
-      case
-        when engine like 'docdb' and enabled_cloudwatch_logs_exports ?& array ['error', 'slowquery']
-        then title || ' ' || engine || ' logging enabled.'
-        else title || ' logging not enabled.'
-      end as reason
-      ${local.tag_dimensions_sql}
-      ${local.common_dimensions_sql}
-    from
-      aws_docdb_cluster_instance;
+      aws_rds_db_instance;
   EOQ
 }
 

--- a/conformance_pack/rds.sp
+++ b/conformance_pack/rds.sp
@@ -572,7 +572,26 @@ query "rds_db_instance_logging_enabled" {
       ${local.tag_dimensions_sql}
       ${local.common_dimensions_sql}
     from
-      aws_rds_db_instance;
+      aws_rds_db_instance
+
+    union
+    
+    select
+      db_instance_arn as resource,
+      engine,
+      case
+        when engine like 'docdb' and enabled_cloudwatch_logs_exports ?& array ['error', 'slowquery'] then 'ok'
+        else 'alarm'
+      end as status,
+      case
+        when engine like 'docdb' and enabled_cloudwatch_logs_exports ?& array ['error', 'slowquery']
+        then title || ' ' || engine || ' logging enabled.'
+        else title || ' logging not enabled.'
+      end as reason
+      ${local.tag_dimensions_sql}
+      ${local.common_dimensions_sql}
+    from
+      aws_docdb_cluster_instance;
   EOQ
 }
 

--- a/other_checks/other.sp
+++ b/other_checks/other.sp
@@ -22,6 +22,7 @@ benchmark "other" {
     control.cloudwatch_cross_account_sharing,
     control.codebuild_project_build_greater_then_90_days,
     control.codebuild_project_with_user_controlled_buildspec,
+    control.docdb_cluster_instance_logging_enabled,
     control.ec2_instance_no_high_level_finding_in_inspector_scan,
     control.ec2_instance_no_launch_wizard_security_group,
     control.ec2_instance_publicly_accessible_iam_profile_attached,


### PR DESCRIPTION
```sql
> query.rds_db_instance_logging_enabled
+-----------------------------------------------------------------+--------------+--------+------------------------------------------------+-----------+--------------+
| resource                                                        | engine       | status | reason                                         | region    | account_id   |
+-----------------------------------------------------------------+--------------+--------+------------------------------------------------+-----------+--------------+
| arn:aws:rds:us-east-1:123793682495:db:database-1-instance-1     | aurora-mysql | alarm  | database-1-instance-1 logging not enabled.     | us-east-1 | 123793682495 |
| arn:aws:rds:us-east-1:123793682495:db:docdb-2023-06-01-14-12-13 | docdb        | alarm  | docdb-2023-06-01-14-12-13 logging not enabled. | us-east-1 | 123793682495 |
+-----------------------------------------------------------------+--------------+--------+------------------------------------------------+-----------+--------------+
```