### PR TITLE
Update query `iam_role_unused_60` to use the correct resource and common dimension

### DIFF
--- a/conformance_pack/iam.sp
+++ b/conformance_pack/iam.sp
@@ -1755,8 +1755,7 @@ query "iam_user_unused_credentials_45" {
 query "iam_role_unused_60" {
   sql = <<-EOQ
     select
-      name,
-      role_last_used_date,
+      arn as resource,
       case
         when role_last_used_date <= (current_date - interval '60' day) or role_last_used_date is null
           then 'alarm'
@@ -1765,9 +1764,10 @@ query "iam_role_unused_60" {
       case
         when role_last_used_date is null
           then name || ' was never used.'
-        else 
+        else
           name || ' was last used ' || to_char(role_last_used_date , 'DD-Mon-YYYY') || ' (' || extract(day from current_date - role_last_used_date) || ' days ago).'
       end as reason
+      ${local.common_dimensions_global_sql}
     from
       aws_iam_role;
   EOQ


### PR DESCRIPTION
```
madhushreeray ~/turbot/steampipe-mod-aws-compliance [issue-662-reopened] $ steampipe check control.iam_role_unused_60 limit 10

+ IAM roles that have not been used in 60 days should be removed ................................................................................................................ 242 / 282 [==========]
  | 
  ALARM: AWSCodePipelineServiceRole-us-east-1-testmr was last used 27-Sep-2022 (268 days ago). .................................................................................... aws_aab 111111111111
  ALARM: AWSCodePipelineServiceRole-us-east-1-pipeline78 was last used 20-Mar-2023 (94 days ago). ................................................................................. aws_aab 111111111111
  ALARM: AWSServiceRoleForKafka was last used 20-Sep-2022 (275 days ago). ......................................................................................................... aws_aab 111111111111
  ALARM: aws-vault-cred-test was last used 14-Feb-2023 (128 days ago). ............................................................................................................ aws_aab 111111111111
  ALARM: AWSServiceRoleForBackupReports was last used 01-Jul-2022 (356 days ago). ................................................................................................. aws_aab 111111111111
  ALARM: AWSDataLifecycleManagerDefaultRoleForAMIManagement was last used 07-Feb-2023 (135 days ago). ............................................................................. aws_aab 111111111111
  ALARM: AmazonSageMaker-ExecutionRole-20230224T215028 was never used. ............................................................................................................ aws_aab 111111111111
  ALARM: AWSServiceRoleForMarketplaceLicenseManagement was last used 27-Feb-2023 (115 days ago). .................................................................................. aws_aab 111111111111
  ALARM: aws-elasticbeanstalk-ec2-role was never used. ............................................................................................................................ aws_aab 111111111111
  ALARM: aws-ec2-spot-fleet-tagging-role was last used 17-Aug-2022 (309 days ago). ................................................................................................ aws_aab 111111111111

```
