### PR TITLE
Add/Update AWS Audit Manager > PCI DSS V321 controls (2023-07-04). Closes #680

### DIFF
--- a/conformance_pack/rds.sp
+++ b/conformance_pack/rds.sp
@@ -245,6 +245,7 @@ control "rds_db_instance_iam_authentication_enabled" {
     hipaa_security_rule_2003               = "true"
     nist_800_171_rev_2                     = "true"
     nist_csf                               = "true"
+    pci_dss_v321                           = "true"
     soc_2                                  = "true"
   })
 }
@@ -257,7 +258,6 @@ control "rds_db_cluster_iam_authentication_enabled" {
   tags = merge(local.conformance_pack_rds_common_tags, {
     nist_800_171_rev_2 = "true"
     nist_csf           = "true"
-    pci_dss_v321       = "true"
   })
 }
 

--- a/pci_dss_v321/requirement_10.sp
+++ b/pci_dss_v321/requirement_10.sp
@@ -417,6 +417,7 @@ benchmark "pci_dss_v321_requirement_10_5_5" {
   description = "File-integrity monitoring or change-detection systems check for changes to critical files, and notify when such changes are noted. For file- integrity monitoring purposes, an entity usually monitors files that don't regularly change, but when changed indicate a possible compromise."
 
   children = [
+    control.cloudtrail_trail_validation_enabled,
     control.s3_bucket_versioning_enabled
   ]
 

--- a/pci_dss_v321/requirement_8.sp
+++ b/pci_dss_v321/requirement_8.sp
@@ -466,7 +466,7 @@ benchmark "pci_dss_v321_requirement_8_7_a" {
   description = "Without user authentication for access to databases and applications, the potential for unauthorized or malicious access increases, and such access cannot be logged since the user has not been authenticated and is therefore not known to the system. Also, database access should be granted through programmatic methods only (for example, through stored procedures), rather than via direct access to the database by end users (except for DBAs, who may need direct access to the database for their administrative duties)."
 
   children = [
-    control.rds_db_cluster_iam_authentication_enabled
+    control.rds_db_instance_iam_authentication_enabled
   ]
 
   tags = merge(local.pci_dss_v321_requirement_8_common_tags, {
@@ -479,7 +479,7 @@ benchmark "pci_dss_v321_requirement_8_7_b" {
   description = "Without user authentication for access to databases and applications, the potential for unauthorized or malicious access increases, and such access cannot be logged since the user has not been authenticated and is therefore not known to the system. Also, database access should be granted through programmatic methods only (for example, through stored procedures), rather than via direct access to the database by end users (except for DBAs, who may need direct access to the database for their administrative duties)."
 
   children = [
-    control.rds_db_cluster_iam_authentication_enabled
+    control.rds_db_instance_iam_authentication_enabled
   ]
 
   tags = merge(local.pci_dss_v321_requirement_8_common_tags, {
@@ -492,7 +492,7 @@ benchmark "pci_dss_v321_requirement_8_7_c" {
   description = "Without user authentication for access to databases and applications, the potential for unauthorized or malicious access increases, and such access cannot be logged since the user has not been authenticated and is therefore not known to the system. Also, database access should be granted through programmatic methods only (for example, through stored procedures), rather than via direct access to the database by end users (except for DBAs, who may need direct access to the database for their administrative duties)."
 
   children = [
-    control.rds_db_cluster_iam_authentication_enabled
+    control.rds_db_instance_iam_authentication_enabled
   ]
 
   tags = merge(local.pci_dss_v321_requirement_8_common_tags, {
@@ -505,7 +505,7 @@ benchmark "pci_dss_v321_requirement_8_7_d" {
   description = "Without user authentication for access to databases and applications, the potential for unauthorized or malicious access increases, and such access cannot be logged since the user has not been authenticated and is therefore not known to the system. Also, database access should be granted through programmatic methods only (for example, through stored procedures), rather than via direct access to the database by end users (except for DBAs, who may need direct access to the database for their administrative duties)."
 
   children = [
-    control.rds_db_cluster_iam_authentication_enabled
+    control.rds_db_instance_iam_authentication_enabled
   ]
 
   tags = merge(local.pci_dss_v321_requirement_8_common_tags, {


### PR DESCRIPTION
Control Added:

Benchmark | Control(s)
-- | --
10_5_5 | cloud_trail_log_file_validation_enabled
8_7_a | rds_instance_iam_authentication_enabled
8_7_b | rds_instance_iam_authentication_enabled
8_7_c | rds_instance_iam_authentication_enabled
8_7_d | rds_instance_iam_authentication_enabled

Controls Removed:

Benchmark | Control(s)
-- | --
8_7_a | rds_db_cluster_iam_authentication_enabled
8_7_b | rds_db_cluster_iam_authentication_enabled
8_7_c | rds_db_cluster_iam_authentication_enabled
8_7_d | rds_db_cluster_iam_authentication_enabled

**Overall Unique Controls Added/Removed**
Only 1 unique control got **replaced**:
**rds_db_cluster_iam_authentication_enabled** > **rds_db_instance_iam_authentication_enabled**


