### PR TITLE
Update supported lambda runtimes

### DIFF
--- a/conformance_pack/lambda.sp
+++ b/conformance_pack/lambda.sp
@@ -123,7 +123,7 @@ control "lambda_function_multiple_az_configured" {
 
 control "lambda_function_use_latest_runtime" {
   title       = "Lambda functions should use latest runtimes"
-  description = "This control checks that the Lambda function settings for runtimes match the expected values set for the latest runtimes for each supported language. This control checks for the following runtimes: nodejs18.x, nodejs16.x, nodejs14.x, python3.10, python3.9, python3.8, python3.7, ruby3.2, ruby2.7, java17, java11, java8, java8.al2, go1.x, dotnet7, dotnet6"
+  description = "This control checks that the Lambda function settings for runtimes match the expected values set for the latest runtimes for each supported language. This control checks for the following runtimes: nodejs20.x, nodejs18.x, nodejs16.x, python3.12, python3.11, python3.10, python3.9, python3.8, ruby3.2, java21, java17, java11, java8.al2, dotnet8, dotnet7, dotnet6, provided.al2023, provided.al2"
   query       = query.lambda_function_use_latest_runtime
 
   tags = merge(local.conformance_pack_lambda_common_tags, {
@@ -365,12 +365,12 @@ query "lambda_function_use_latest_runtime" {
       arn as resource,
       case
         when package_type <> 'Zip' then 'skip'
-        when runtime in ('nodejs18.x', 'nodejs16.x', 'nodejs14.x', 'python3.10', 'python3.9', 'python3.8', 'python3.7', 'ruby3.2', 'ruby2.7', 'java17', 'java11', 'java8', 'java8.al2', 'go1.x', 'dotnet7', 'dotnet6') then 'ok'
+        when runtime in ('nodejs20.x', 'nodejs18.x', 'nodejs16.x', 'python3.12', 'python3.11', 'python3.10', 'python3.9', 'python3.8', 'ruby3.2', 'java21', 'java17', 'java11', 'java8.al2', 'dotnet8', 'dotnet7', 'dotnet6', 'provided.al2023', 'provided.al2') then 'ok'
         else 'alarm'
       end as status,
       case
         when package_type <> 'Zip' then title || ' package type is ' || package_type || '.'
-        when runtime in ('nodejs18.x', 'nodejs16.x', 'nodejs14.x', 'python3.10', 'python3.9', 'python3.8', 'python3.7', 'ruby3.2', 'ruby2.7', 'java17', 'java11', 'java8', 'java8.al2', 'go1.x', 'dotnet7', 'dotnet6') then title || ' uses latest runtime - ' || runtime || '.'
+        when runtime in ('nodejs20.x', 'nodejs18.x', 'nodejs16.x', 'python3.12', 'python3.11', 'python3.10', 'python3.9', 'python3.8', 'ruby3.2', 'java21', 'java17', 'java11', 'java8.al2', 'dotnet8', 'dotnet7', 'dotnet6', 'provided.al2023', 'provided.al2') then title || ' uses latest runtime - ' || runtime || '.'
         else title || ' uses ' || runtime || ' which is not the latest version.'
       end as reason
       ${local.tag_dimensions_sql}

--- a/conformance_pack/lambda.sp
+++ b/conformance_pack/lambda.sp
@@ -123,7 +123,7 @@ control "lambda_function_multiple_az_configured" {
 
 control "lambda_function_use_latest_runtime" {
   title       = "Lambda functions should use latest runtimes"
-  description = "This control checks that the Lambda function settings for runtimes match the expected values set for the latest runtimes for each supported language. This control checks for the following runtimes: nodejs20.x, nodejs18.x, nodejs16.x, python3.12, python3.11, python3.10, python3.9, python3.8, ruby3.2, java21, java17, java11, java8.al2, dotnet8, dotnet7, dotnet6, provided.al2023, provided.al2"
+  description = "This control checks that the Lambda function settings for runtimes match the expected values set for the latest runtimes for each supported language. This control checks for the following runtimes: nodejs20.x, nodejs18.x, nodejs16.x, python3.12, python3.11, python3.10, python3.9, python3.8, ruby3.3, ruby3.2, java21, java17, java11, java8.al2, dotnet8, dotnet6"
   query       = query.lambda_function_use_latest_runtime
 
   tags = merge(local.conformance_pack_lambda_common_tags, {
@@ -365,12 +365,12 @@ query "lambda_function_use_latest_runtime" {
       arn as resource,
       case
         when package_type <> 'Zip' then 'skip'
-        when runtime in ('nodejs20.x', 'nodejs18.x', 'nodejs16.x', 'python3.12', 'python3.11', 'python3.10', 'python3.9', 'python3.8', 'ruby3.2', 'java21', 'java17', 'java11', 'java8.al2', 'dotnet8', 'dotnet7', 'dotnet6', 'provided.al2023', 'provided.al2') then 'ok'
+        when runtime in ('nodejs20.x', 'nodejs18.x', 'nodejs16.x', 'python3.12', 'python3.11', 'python3.10', 'python3.9', 'python3.8', 'ruby3.3', 'ruby3.2', 'java21', 'java17', 'java11', 'java8.al2', 'dotnet8', 'dotnet6') then 'ok'
         else 'alarm'
       end as status,
       case
         when package_type <> 'Zip' then title || ' package type is ' || package_type || '.'
-        when runtime in ('nodejs20.x', 'nodejs18.x', 'nodejs16.x', 'python3.12', 'python3.11', 'python3.10', 'python3.9', 'python3.8', 'ruby3.2', 'java21', 'java17', 'java11', 'java8.al2', 'dotnet8', 'dotnet7', 'dotnet6', 'provided.al2023', 'provided.al2') then title || ' uses latest runtime - ' || runtime || '.'
+        when runtime in ('nodejs20.x', 'nodejs18.x', 'nodejs16.x', 'python3.12', 'python3.11', 'python3.10', 'python3.9', 'python3.8', 'ruby3.3', 'ruby3.2', 'java21', 'java17', 'java11', 'java8.al2', 'dotnet8', 'dotnet6') then title || ' uses latest runtime - ' || runtime || '.'
         else title || ' uses ' || runtime || ' which is not the latest version.'
       end as reason
       ${local.tag_dimensions_sql}

--- a/foundational_security/docs/foundational_security_lambda_2.md
+++ b/foundational_security/docs/foundational_security_lambda_2.md
@@ -1,6 +1,6 @@
 ## Description
 
-This control checks that the Lambda function settings for runtimes match the expected values set for the supported runtimes for each language. This control checks for the following runtimes: `nodejs18.x`, `nodejs16.x`, `nodejs14.x`, `python3.10`, `python3.9`, `python3.8`, `python3.7`, `ruby3.2`, `ruby2.7`, `java17`, `java11`, `java8`, `java8.al2`, `go1.x`, `dotnet7`, `dotnet6`
+This control checks that the Lambda function settings for runtimes match the expected values set for the supported runtimes for each language. This control checks for the following runtimes: `nodejs20.x`, `nodejs18.x`, `nodejs16.x`, `python3.12`, `python3.11`, `python3.10`, `python3.9`, `python3.8`, `ruby3.2`, `java21`, `java17`, `java11`, `java8.al2`, `dotnet8`, `dotnet7`, `dotnet6`, `provided.al2023`, `provided.al2`
 
 [Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) are built around a combination of operating system, programming language, and software libraries that are subject to maintenance and security updates. When a runtime component is no longer supported for security updates, Lambda deprecates the runtime. Even though you cannot create functions that use the deprecated runtime, the function is still available to process invocation events. Make sure that your Lambda functions are current and do not use out-of-date runtime environments.
 

--- a/foundational_security/docs/foundational_security_lambda_2.md
+++ b/foundational_security/docs/foundational_security_lambda_2.md
@@ -1,6 +1,6 @@
 ## Description
 
-This control checks that the Lambda function settings for runtimes match the expected values set for the supported runtimes for each language. This control checks for the following runtimes: `nodejs20.x`, `nodejs18.x`, `nodejs16.x`, `python3.12`, `python3.11`, `python3.10`, `python3.9`, `python3.8`, `ruby3.2`, `java21`, `java17`, `java11`, `java8.al2`, `dotnet8`, `dotnet7`, `dotnet6`, `provided.al2023`, `provided.al2`
+This control checks that the Lambda function settings for runtimes match the expected values set for the supported runtimes for each language. This control checks for the following runtimes: `nodejs20.x`, `nodejs18.x`, `nodejs16.x`, `python3.12`, `python3.11`, `python3.10`, `python3.9`, `python3.8`, `ruby3.3`, `ruby3.2`, `java21`, `java17`, `java11`, `java8.al2`, `dotnet8`, `dotnet6`
 
 [Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) are built around a combination of operating system, programming language, and software libraries that are subject to maintenance and security updates. When a runtime component is no longer supported for security updates, Lambda deprecates the runtime. Even though you cannot create functions that use the deprecated runtime, the function is still available to process invocation events. Make sure that your Lambda functions are current and do not use out-of-date runtime environments.
 

--- a/foundational_security/lambda.sp
+++ b/foundational_security/lambda.sp
@@ -33,7 +33,7 @@ control "foundational_security_lambda_1" {
 
 control "foundational_security_lambda_2" {
   title         = "2 Lambda functions should use supported runtimes"
-  description   = "This control checks that the Lambda function settings for runtimes match the expected values set for the latest runtimes for each supported language. This control checks for the following runtimes: nodejs18.x, nodejs16.x, nodejs14.x, python3.10, python3.9, python3.8, python3.7, ruby3.2, ruby2.7, java17, java11, java8, java8.al2, go1.x, dotnet7, dotnet6"
+  description   = "This control checks that the Lambda function settings for runtimes match the expected values set for the latest runtimes for each supported language. This control checks for the following runtimes: nodejs20.x, nodejs18.x, nodejs16.x, python3.12, python3.11, python3.10, python3.9, python3.8, ruby3.2, java21, java17, java11, java8.al2, dotnet8, dotnet7, dotnet6, provided.al2023, provided.al2"
   severity      = "medium"
   query         = query.lambda_function_use_latest_runtime
   documentation = file("./foundational_security/docs/foundational_security_lambda_2.md")

--- a/foundational_security/lambda.sp
+++ b/foundational_security/lambda.sp
@@ -33,7 +33,7 @@ control "foundational_security_lambda_1" {
 
 control "foundational_security_lambda_2" {
   title         = "2 Lambda functions should use supported runtimes"
-  description   = "This control checks that the Lambda function settings for runtimes match the expected values set for the latest runtimes for each supported language. This control checks for the following runtimes: nodejs20.x, nodejs18.x, nodejs16.x, python3.12, python3.11, python3.10, python3.9, python3.8, ruby3.2, java21, java17, java11, java8.al2, dotnet8, dotnet7, dotnet6, provided.al2023, provided.al2"
+  description   = "This control checks that the Lambda function settings for runtimes match the expected values set for the latest runtimes for each supported language. This control checks for the following runtimes: nodejs20.x, nodejs18.x, nodejs16.x, python3.12, python3.11, python3.10, python3.9, python3.8, ruby3.3, ruby3.2, java21, java17, java11, java8.al2, dotnet8, dotnet6"
   severity      = "medium"
   query         = query.lambda_function_use_latest_runtime
   documentation = file("./foundational_security/docs/foundational_security_lambda_2.md")


### PR DESCRIPTION
### Checklist
- [ ] Issue(s) linked

### Description
This change updates the list of supported AWS lambda runtimes according to the [service documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
