### PR TITLE
set lambda python3.8 as deprecated runtime

### DIFF
--- a/conformance_pack/lambda.pp
+++ b/conformance_pack/lambda.pp
@@ -1,13 +1,13 @@
 variable "lambda_latest_runtimes" {
   type        = list(string)
   description = "A list of latest lambda runtimes."
-  default     = ["nodejs20.x", "nodejs18.x", "nodejs16.x", "python3.12", "python3.11", "python3.10", "python3.9", "python3.8", "ruby3.3", "ruby3.2", "java21", "java17", "java11", "java8.al2", "dotnet8", "dotnet6"]
+  default     = ["nodejs20.x", "nodejs18.x", "nodejs16.x", "python3.12", "python3.11", "python3.10", "python3.9", "ruby3.3", "ruby3.2", "java21", "java17", "java11", "java8.al2", "dotnet8", "dotnet6"]
 }
 
 variable "lambda_deprecated_runtimes" {
   type        = list(string)
   description = "A list of deprecated lambda runtimes."
-  default     = ["java8", "go1.x", "provided", "ruby2.7", "nodejs14.x", "python3.7", "dotnetcore3.1", "nodejs12.x", "python3.6", "dotnet5.0", "dotnetcore2.1", "nodejs10.x", "ruby2.5", "python2.7", "nodejs8.10", "nodejs4.3", "nodejs4.3-edge", "nodejs6.10", "dotnetcore1.0", "dotnetcore2.0", "nodejs"]
+  default     = ["java8", "go1.x", "provided", "ruby2.7", "nodejs14.x", "python3.7", "python3.8", "dotnetcore3.1", "nodejs12.x", "python3.6", "dotnet5.0", "dotnetcore2.1", "nodejs10.x", "ruby2.5", "python2.7", "nodejs8.10", "nodejs4.3", "nodejs4.3-edge", "nodejs6.10", "dotnetcore1.0", "dotnetcore2.0", "nodejs"]
 }
 
 locals {


### PR DESCRIPTION
### Description
Lambda runtime python3.8 was deprecated on Oct 14, 2024.
https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated

### Checklist
- [ ] Issue(s) linked
