### PR TITLE
Update query logic for `eks_cluster_control_plane_audit_logging_enabled`

### DIFF
--- a/conformance_pack/eks.pp
+++ b/conformance_pack/eks.pp
@@ -138,7 +138,7 @@ query "eks_cluster_control_plane_audit_logging_enabled" {
         jsonb_array_elements(logging -> 'ClusterLogging') as log
       where
         log ->> 'Enabled' = 'true'
-        and (log -> 'Types') @> '["api", "audit", "authenticator", "controllerManager", "scheduler"]'
+        and (log -> 'Types') @> '["audit"]'
     )
     select
       c.arn as resource,
@@ -147,11 +147,8 @@ query "eks_cluster_control_plane_audit_logging_enabled" {
         else 'alarm'
       end as status,
       case
-        when l.arn is not null then c.title || ' control plane audit logging enabled for all log types.'
-        else
-          case when logging -> 'ClusterLogging' @> '[{"Enabled": true}]' then c.title || ' control plane audit logging not enabled for all log types.'
-          else c.title || ' control plane audit logging not enabled.'
-          end
+        when l.arn is not null then title || ' control plane audit logging enabled.'
+        else title || ' control plane audit logging disabled.'
       end as reason
       ${local.tag_dimensions_sql}
       ${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "c.")}


### PR DESCRIPTION
```sql
with control_panel_audit_logging as (
      select
        distinct arn,
        log -> 'Types' as log_type
      from
        aws_eks_cluster,
        jsonb_array_elements(logging -> 'ClusterLogging') as log
      where
        log ->> 'Enabled' = 'true'
        and (log -> 'Types') @> '["audit"]'
    )
    select
      c.arn as resource,
      case
        when l.arn is not null then 'ok'
        else 'alarm'
      end as status,
      case
        when l.arn is not null then title || ' audit logging enabled.'
        else title || ' audit logging disabled.'
      end as reason
    from
      aws_eks_cluster as c
      left join control_panel_audit_logging as l on l.arn = c.arn;
+--------------------------------------------------------------------+--------+------------------------------------------------+
| resource                                                           | status | reason                                         |
+--------------------------------------------------------------------+--------+------------------------------------------------+
| arn:aws:eks:us-east-1:888888888888:cluster/test_other_service      | alarm  | test_other_service audit logging disabled.     |
| arn:aws:eks:us-east-1:888888888888:cluster/test_all_disabled       | alarm  | test_all_disabled audit logging disabled.      |
| arn:aws:eks:us-east-1:888888888888:cluster/test_only_audit_enabled | ok     | test_only_audit_enabled audit logging enabled. |
| arn:aws:eks:us-east-1:888888888888:cluster/test-all                | ok     | test-all audit logging enabled.                |
+--------------------------------------------------------------------+--------+------------------------------------------------+
```