### PR TITLE
Fix `sns_topic_policy_prohibit_public_access` and `sns_topic_policy_prohibit_cross_account_access` queries to consider all the conditions for deriving the results

### DIFF
--- a/conformance_pack/ec2.pp
+++ b/conformance_pack/ec2.pp
@@ -661,8 +661,8 @@ query "ec2_instance_no_high_level_finding_in_inspector_scan" {
         when l.instance_id is null then i.title || ' has no high level finding in inspector scans.'
         else i.title || ' has ' || (select count(*) from severity_list where instance_id = i.instance_id) || ' high level findings in inspector scans.'
       end as reason
-      -- ${local.tag_dimensions_sql}
-      -- ${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "i.")}
+      ${local.tag_dimensions_sql}
+      ${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "i.")}
     from
       aws_ec2_instance as i
       left join ec2_istance_list as l on i.instance_id = l.instance_id;

--- a/conformance_pack/ec2.pp
+++ b/conformance_pack/ec2.pp
@@ -633,7 +633,7 @@ query "ec2_instance_no_high_level_finding_in_inspector_scan" {
   sql = <<-EOQ
     with severity_list as (
       select
-        distinct title ,
+        distinct title,
         a ->> 'Value' as instance_id
       from
         aws_inspector_finding,
@@ -661,8 +661,8 @@ query "ec2_instance_no_high_level_finding_in_inspector_scan" {
         when l.instance_id is null then i.title || ' has no high level finding in inspector scans.'
         else i.title || ' has ' || (select count(*) from severity_list where instance_id = i.instance_id) || ' high level findings in inspector scans.'
       end as reason
-      ${local.tag_dimensions_sql}
-      ${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "i.")}
+      -- ${local.tag_dimensions_sql}
+      -- ${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "i.")}
     from
       aws_ec2_instance as i
       left join ec2_istance_list as l on i.instance_id = l.instance_id;

--- a/conformance_pack/sns.pp
+++ b/conformance_pack/sns.pp
@@ -376,7 +376,7 @@ query "sns_topic_policy_prohibit_cross_account_access" {
       end as status,
       case
         when p.topic_arn is null then title || ' does not allow cross account access.'
-        else title || ' contains ' || coalesce(p.statements_num,0) || ' statements that allows cross account access.'
+        else title || ' contains ' || coalesce(p.statements_num,0) || ' statements that allow cross account access.'
       end as reason
       ${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "t.")}
       ${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "t.")}

--- a/conformance_pack/sns.pp
+++ b/conformance_pack/sns.pp
@@ -103,9 +103,10 @@ query "sns_topic_policy_prohibit_public_access" {
       where
         s ->> 'Effect' = 'Allow'
         and (
-          ( s -> 'Principal' -> 'AWS') = '["*"]'
+          (s -> 'Principal' -> 'AWS') = '["*"]'
           or s ->> 'Principal' = '*'
         )
+        and s -> 'Condition' is null
       group by
         topic_arn
     )
@@ -250,6 +251,7 @@ query "sns_topic_policy_prohibit_cross_account_access" {
           or s ->> 'Principal' = '*'
           or split_part(p, ':', 5) <> account_id
         )
+        and s -> 'Condition' is null
       group by
         topic_arn
     )


### PR DESCRIPTION
New queries:
```
with wildcard_action_policies as (
        select
          topic_arn,
          count(*) as statements_num
        from
          aws_sns_topic,
          jsonb_array_elements(policy_std -> 'Statement') as s
        where
          s ->> 'Effect' = 'Allow'
          -- aws:SourceOwner
          and s -> 'Condition' -> 'StringEquals' -> 'aws:sourceowner' is null
          and s -> 'Condition' -> 'StringEqualsIgnoreCase' -> 'aws:sourceowner' is null
          and (
            s -> 'Condition' -> 'StringLike' -> 'aws:sourceowner' is null
            or s -> 'Condition' -> 'StringLike' -> 'aws:sourceowner' ? '*'
        )
        -- aws:SourceAccount
        and s -> 'Condition' -> 'StringEquals' -> 'aws:sourceaccount' is null
        and s -> 'Condition' -> 'StringEqualsIgnoreCase' -> 'aws:sourceaccount' is null
        and (
          s -> 'Condition' -> 'StringLike' -> 'aws:sourceaccount' is null
          or s -> 'Condition' -> 'StringLike' -> 'aws:sourceaccount' ? '*'
        )
        -- aws:PrincipalOrgID
        and s -> 'Condition' -> 'StringEquals' -> 'aws:principalorgid' is null
        and s -> 'Condition' -> 'StringEqualsIgnoreCase' -> 'aws:principalorgid' is null
        and (
          s -> 'Condition' -> 'StringLike' -> 'aws:principalorgid' is null
          or s -> 'Condition' -> 'StringLike' -> 'aws:principalorgid' ? '*'
        )
        -- aws:PrincipalAccount
        and s -> 'Condition' -> 'StringEquals' -> 'aws:principalaccount' is null
        and s -> 'Condition' -> 'StringEqualsIgnoreCase' -> 'aws:principalaccount' is null
        and (
          s -> 'Condition' -> 'StringLike' -> 'aws:principalaccount' is null
          or s -> 'Condition' -> 'StringLike' -> 'aws:principalaccount' ? '*'
        )
        -- aws:PrincipalArn
        and s -> 'Condition' -> 'StringEquals' -> 'aws:principalarn' is null
        and s -> 'Condition' -> 'StringEqualsIgnoreCase' -> 'aws:principalarn' is null
        and (
          s -> 'Condition' -> 'StringLike' -> 'aws:principalarn' is null
          or s -> 'Condition' -> 'StringLike' -> 'aws:principalarn' ? '*'
        )
        and (
          s -> 'Condition' -> 'ArnEquals' -> 'aws:principalarn' is null
          or s -> 'Condition' -> 'ArnEquals' -> 'aws:principalarn' ? '*'
        )
        and (
          s -> 'Condition' -> 'ArnLike' -> 'aws:principalarn' is null
          or s -> 'Condition' -> 'ArnLike' -> 'aws:principalarn' ? '*'
        )
        -- aws:SourceArn
        and s -> 'Condition' -> 'StringEquals' -> 'aws:sourcearn' is null
        and s -> 'Condition' -> 'StringEqualsIgnoreCase' -> 'aws:sourcearn' is null
        and (
          s -> 'Condition' -> 'StringLike' -> 'aws:sourcearn' is null
          or s -> 'Condition' -> 'StringLike' -> 'aws:sourcearn' ? '*'
        )
        and (
          s -> 'Condition' -> 'ArnEquals' -> 'aws:sourcearn' is null
          or s -> 'Condition' -> 'ArnEquals' -> 'aws:sourcearn' ? '*'
        )
        and (
          s -> 'Condition' -> 'ArnLike' -> 'aws:sourcearn' is null
          or s -> 'Condition' -> 'ArnLike' -> 'aws:sourcearn' ? '*'
        )
        and (
          s -> 'Principal' -> 'AWS' = '["*"]'
          or s ->> 'Principal' = '*'
        )
      group by
        topic_arn
    )
    select
      t.topic_arn as resource,
      case
        when p.topic_arn is null then 'ok'
        else 'alarm'
      end as status,
      case
        when p.topic_arn is null then title || ' does not allow public access.'
        else title || ' contains ' || coalesce(p.statements_num,0) ||
        ' statements that allows public access.'
      end as reason
      -- ${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "t.")}
      -- ${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "t.")}
    from
      aws_sns_topic as t
      left join wildcard_action_policies as p on p.topic_arn = t.topic_arn
where t.topic_arn in ('arn:aws:sns:us-east-1:333333333333:topic-with-sourceowner-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-sourceaccount-condition','arn:aws:sns:us-east-1:333333333333:topic-with-principalorgid-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-principalaccount-condition','arn:aws:sns:us-east-1:333333333333:topic-with-principalarn-condition','arn:aws:sns:us-east-1:333333333333:topic-with-sourcearn-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-multiple-conditions','arn:aws:sns:us-east-1:333333333333:topic-cross-account-sourcearn');
+--------------------------------------------------------------------------+--------+---------------------------------------------------------------------+
| resource                                                                 | status | reason                                                              |
+--------------------------------------------------------------------------+--------+---------------------------------------------------------------------+
| arn:aws:sns:us-east-1:333333333333:topic-with-sourcearn-condition        | ok     | topic-with-sourcearn-condition does not allow public access.        |
| arn:aws:sns:us-east-1:333333333333:topic-cross-account-sourcearn         | ok     | topic-cross-account-sourcearn does not allow public access.         |
| arn:aws:sns:us-east-1:333333333333:topic-with-sourceowner-condition      | ok     | topic-with-sourceowner-condition does not allow public access.      |
| arn:aws:sns:us-east-1:333333333333:topic-with-principalorgid-condition   | ok     | topic-with-principalorgid-condition does not allow public access.   |
| arn:aws:sns:us-east-1:333333333333:topic-with-multiple-conditions        | ok     | topic-with-multiple-conditions does not allow public access.        |
| arn:aws:sns:us-east-1:333333333333:topic-with-sourceaccount-condition    | ok     | topic-with-sourceaccount-condition does not allow public access.    |
| arn:aws:sns:us-east-1:333333333333:topic-with-principalaccount-condition | ok     | topic-with-principalaccount-condition does not allow public access. |
| arn:aws:sns:us-east-1:333333333333:topic-with-principalarn-condition     | ok     | topic-with-principalarn-condition does not allow public access.     |
+--------------------------------------------------------------------------+--------+---------------------------------------------------------------------+
```

```
with cross_account_policies as (
      select
        topic_arn,
        count(*) as statements_num
      from
        aws_sns_topic,
        jsonb_array_elements(policy_std -> 'Statement') as s,
        jsonb_array_elements_text(s -> 'Principal' -> 'AWS') as p
      where
        s ->> 'Effect' = 'Allow'
        and (
          ( s -> 'Principal' -> 'AWS') = '["*"]'
          or s ->> 'Principal' = '*'
          or split_part(p, ':', 5) <> account_id
        )
        and s -> 'Condition' -> 'StringEquals' -> 'aws:sourceowner' is null
          and s -> 'Condition' -> 'StringEqualsIgnoreCase' -> 'aws:sourceowner' is null
          and (
            s -> 'Condition' -> 'StringLike' -> 'aws:sourceowner' is null
            or s -> 'Condition' -> 'StringLike' -> 'aws:sourceowner' ? '*'
        )
        -- aws:SourceAccount
        and s -> 'Condition' -> 'StringEquals' -> 'aws:sourceaccount' is null
        and s -> 'Condition' -> 'StringEqualsIgnoreCase' -> 'aws:sourceaccount' is null
        and (
          s -> 'Condition' -> 'StringLike' -> 'aws:sourceaccount' is null
          or s -> 'Condition' -> 'StringLike' -> 'aws:sourceaccount' ? '*'
        )
        -- aws:PrincipalOrgID
        and s -> 'Condition' -> 'StringEquals' -> 'aws:principalorgid' is null
        and s -> 'Condition' -> 'StringEqualsIgnoreCase' -> 'aws:principalorgid' is null
        and (
          s -> 'Condition' -> 'StringLike' -> 'aws:principalorgid' is null
          or s -> 'Condition' -> 'StringLike' -> 'aws:principalorgid' ? '*'
        )
        -- aws:PrincipalAccount
        and s -> 'Condition' -> 'StringEquals' -> 'aws:principalaccount' is null
        and s -> 'Condition' -> 'StringEqualsIgnoreCase' -> 'aws:principalaccount' is null
        and (
          s -> 'Condition' -> 'StringLike' -> 'aws:principalaccount' is null
          or s -> 'Condition' -> 'StringLike' -> 'aws:principalaccount' ? '*'
        )
        -- aws:PrincipalArn
        and s -> 'Condition' -> 'StringEquals' -> 'aws:principalarn' is null
        and s -> 'Condition' -> 'StringEqualsIgnoreCase' -> 'aws:principalarn' is null
        and (
          s -> 'Condition' -> 'StringLike' -> 'aws:principalarn' is null
          or s -> 'Condition' -> 'StringLike' -> 'aws:principalarn' ? '*'
        )
        and (
          s -> 'Condition' -> 'ArnEquals' -> 'aws:principalarn' is null
          or s -> 'Condition' -> 'ArnEquals' -> 'aws:principalarn' ? '*'
        )
        and (
          s -> 'Condition' -> 'ArnLike' -> 'aws:principalarn' is null
          or s -> 'Condition' -> 'ArnLike' -> 'aws:principalarn' ? '*'
        )
        -- aws:SourceArn
        and s -> 'Condition' -> 'StringEquals' -> 'aws:sourcearn' is null
        and s -> 'Condition' -> 'StringEqualsIgnoreCase' -> 'aws:sourcearn' is null
        and (
          s -> 'Condition' -> 'StringLike' -> 'aws:sourcearn' is null
          or s -> 'Condition' -> 'StringLike' -> 'aws:sourcearn' ? '*'
        )
        and (
          s -> 'Condition' -> 'ArnEquals' -> 'aws:sourcearn' is null
          or s -> 'Condition' -> 'ArnEquals' -> 'aws:sourcearn' ? '*'
        )
        and (
          s -> 'Condition' -> 'ArnLike' -> 'aws:sourcearn' is null
          or s -> 'Condition' -> 'ArnLike' -> 'aws:sourcearn' ? '*'
        )
      group by
        topic_arn
    )
    select
      t.topic_arn as resource,
      case
        when p.topic_arn is null then 'ok'
        else 'alarm'
      end as status,
      case
        when p.topic_arn is null then title || ' does not allow cross account access.'
        else title || ' contains ' || coalesce(p.statements_num,0) || ' statements that allows cross account access.'
      end as reason
      -- ${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "t.")}
      -- ${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "t.")}
    from
      aws_sns_topic as t
      left join cross_account_policies as p on p.topic_arn = t.topic_arn 
where t.topic_arn in ('arn:aws:sns:us-east-1:333333333333:topic-with-sourceowner-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-sourceaccount-condition','arn:aws:sns:us-east-1:333333333333:topic-with-principalorgid-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-principalaccount-condition','arn:aws:sns:us-east-1:333333333333:topic-with-principalarn-condition','arn:aws:sns:us-east-1:333333333333:topic-with-sourcearn-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-multiple-conditions','arn:aws:sns:us-east-1:333333333333:topic-cross-account-sourcearn');
+--------------------------------------------------------------------------+--------+----------------------------------------------------------------------------+
| resource                                                                 | status | reason                                                                     |
+--------------------------------------------------------------------------+--------+----------------------------------------------------------------------------+
| arn:aws:sns:us-east-1:333333333333:topic-with-sourcearn-condition        | ok     | topic-with-sourcearn-condition does not allow cross account access.        |
| arn:aws:sns:us-east-1:333333333333:topic-cross-account-sourcearn         | ok     | topic-cross-account-sourcearn does not allow cross account access.         |
| arn:aws:sns:us-east-1:333333333333:topic-with-sourceowner-condition      | ok     | topic-with-sourceowner-condition does not allow cross account access.      |
| arn:aws:sns:us-east-1:333333333333:topic-with-principalorgid-condition   | ok     | topic-with-principalorgid-condition does not allow cross account access.   |
| arn:aws:sns:us-east-1:333333333333:topic-with-multiple-conditions        | ok     | topic-with-multiple-conditions does not allow cross account access.        |
| arn:aws:sns:us-east-1:333333333333:topic-with-sourceaccount-condition    | ok     | topic-with-sourceaccount-condition does not allow cross account access.    |
| arn:aws:sns:us-east-1:333333333333:topic-with-principalaccount-condition | ok     | topic-with-principalaccount-condition does not allow cross account access. |
| arn:aws:sns:us-east-1:333333333333:topic-with-principalarn-condition     | ok     | topic-with-principalarn-condition does not allow cross account access.     |
+--------------------------------------------------------------------------+--------+----------------------------------------------------------------------------+
```

Old queries:
```
with wildcard_action_policies as (
      select
        topic_arn,
        count(*) as statements_num
      from
        aws_sns_topic,
        jsonb_array_elements(policy_std -> 'Statement') as s
      where
        s ->> 'Effect' = 'Allow'
        and (
          ( s -> 'Principal' -> 'AWS') = '["*"]'
          or s ->> 'Principal' = '*'
        )
      group by
        topic_arn
    )
    select
      t.topic_arn as resource,
      case
        when p.topic_arn is null then 'ok'
        else 'alarm'
      end as status,
      case
        when p.topic_arn is null then title || ' does not allow public access.'
        else title || ' contains ' || coalesce(p.statements_num,0) ||
        ' statements that allows public access.'
      end as reason
      --${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "t.")}
      --${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "t.")}
    from
      aws_sns_topic as t
      left join wildcard_action_policies as p on p.topic_arn = t.topic_arn
where t.topic_arn in ('arn:aws:sns:us-east-1:333333333333:topic-with-sourceowner-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-sourceaccount-condition','arn:aws:sns:us-east-1:333333333333:topic-with-principalorgid-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-principalaccount-condition','arn:aws:sns:us-east-1:333333333333:topic-with-principalarn-condition','arn:aws:sns:us-east-1:333333333333:topic-with-sourcearn-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-multiple-conditions','arn:aws:sns:us-east-1:333333333333:topic-cross-account-sourcearn');
+--------------------------------------------------------------------------+--------+------------------------------------------------------------------------------>
| resource                                                                 | status | reason                                                                       >
+--------------------------------------------------------------------------+--------+------------------------------------------------------------------------------>
| arn:aws:sns:us-east-1:333333333333:topic-with-sourcearn-condition        | alarm  | topic-with-sourcearn-condition contains 1 statements that allows public acces>
| arn:aws:sns:us-east-1:333333333333:topic-cross-account-sourcearn         | ok     | topic-cross-account-sourcearn does not allow public access.                  >
| arn:aws:sns:us-east-1:333333333333:topic-with-sourceowner-condition      | alarm  | topic-with-sourceowner-condition contains 1 statements that allows public acc>
| arn:aws:sns:us-east-1:333333333333:topic-with-principalorgid-condition   | alarm  | topic-with-principalorgid-condition contains 1 statements that allows public >
| arn:aws:sns:us-east-1:333333333333:topic-with-multiple-conditions        | alarm  | topic-with-multiple-conditions contains 1 statements that allows public acces>
| arn:aws:sns:us-east-1:333333333333:topic-with-sourceaccount-condition    | alarm  | topic-with-sourceaccount-condition contains 1 statements that allows public a>
| arn:aws:sns:us-east-1:333333333333:topic-with-principalaccount-condition | alarm  | topic-with-principalaccount-condition contains 1 statements that allows publi>
| arn:aws:sns:us-east-1:333333333333:topic-with-principalarn-condition     | alarm  | topic-with-principalarn-condition contains 1 statements that allows public ac>
+--------------------------------------------------------------------------+--------+------------------------------------------------------------------------------>
```

```
with cross_account_policies as (
      select
        topic_arn,
        count(*) as statements_num
      from
        aws_sns_topic,
        jsonb_array_elements(policy_std -> 'Statement') as s,
        jsonb_array_elements_text(s -> 'Principal' -> 'AWS') as p
      where
        s ->> 'Effect' = 'Allow'
        and (
          ( s -> 'Principal' -> 'AWS') = '["*"]'
          or s ->> 'Principal' = '*'
          or split_part(p, ':', 5) <> account_id
        )
      group by
        topic_arn
    )
    select
      t.topic_arn as resource,
      case
        when p.topic_arn is null then 'ok'
        else 'alarm'
      end as status,
      case
        when p.topic_arn is null then title || ' does not allow cross account access.'
        else title || ' contains ' || coalesce(p.statements_num,0) || ' statements that allows cross account access.'
      end as reason
      --${replace(local.tag_dimensions_qualifier_sql, "__QUALIFIER__", "t.")}
      --${replace(local.common_dimensions_qualifier_sql, "__QUALIFIER__", "t.")}
    from
      aws_sns_topic as t
      left join cross_account_policies as p on p.topic_arn = t.topic_arn
where t.topic_arn in ('arn:aws:sns:us-east-1:333333333333:topic-with-sourceowner-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-sourceaccount-condition','arn:aws:sns:us-east-1:333333333333:topic-with-principalorgid-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-principalaccount-condition','arn:aws:sns:us-east-1:333333333333:topic-with-principalarn-condition','arn:aws:sns:us-east-1:333333333333:topic-with-sourcearn-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-multiple-conditions','arn:aws:sns:us-east-1:333333333333:topic-cross-account-sourcearn');
+--------------------------------------------------------------------------+--------+------------------------------------------------------------------------------>
| resource                                                                 | status | reason                                                                       >
+--------------------------------------------------------------------------+--------+------------------------------------------------------------------------------>
| arn:aws:sns:us-east-1:333333333333:topic-with-sourcearn-condition        | alarm  | topic-with-sourcearn-condition contains 1 statements that allows cross accoun>
| arn:aws:sns:us-east-1:333333333333:topic-cross-account-sourcearn         | ok     | topic-cross-account-sourcearn does not allow cross account access.           >
| arn:aws:sns:us-east-1:333333333333:topic-with-sourceowner-condition      | alarm  | topic-with-sourceowner-condition contains 1 statements that allows cross acco>
| arn:aws:sns:us-east-1:333333333333:topic-with-principalorgid-condition   | alarm  | topic-with-principalorgid-condition contains 1 statements that allows cross a>
| arn:aws:sns:us-east-1:333333333333:topic-with-multiple-conditions        | alarm  | topic-with-multiple-conditions contains 1 statements that allows cross accoun>
| arn:aws:sns:us-east-1:333333333333:topic-with-sourceaccount-condition    | alarm  | topic-with-sourceaccount-condition contains 1 statements that allows cross ac>
| arn:aws:sns:us-east-1:333333333333:topic-with-principalaccount-condition | alarm  | topic-with-principalaccount-condition contains 1 statements that allows cross>
| arn:aws:sns:us-east-1:333333333333:topic-with-principalarn-condition     | alarm  | topic-with-principalarn-condition contains 1 statements that allows cross acc>
+--------------------------------------------------------------------------+--------+------------------------------------------------------------------------------>
```

```
select policy_std from aws_sns_topic where topic_arn in ('arn:aws:sns:us-east-1:333333333333:topic-with-sourceowner-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-sourceaccount-condition','arn:aws:sns:us-east-1:333333333333:topic-with-principalorgid-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-principalaccount-condition','arn:aws:sns:us-east-1:333333333333:topic-with-principalarn-condition','arn:aws:sns:us-east-1:333333333333:topic-with-sourcearn-condition', 'arn:aws:sns:us-east-1:333333333333:topic-with-multiple-conditions','arn:aws:sns:us-east-1:333333333333:topic-cross-account-sourcearn');
{
 "columns": [
  {
   "name": "policy_std",
   "data_type": "jsonb"
  }
 ],
 "rows": [
  {
   "policy_std": {
    "Id": "PrincipalOrgIdPolicy",
    "Statement": [
     {
      "Action": [
       "sns:publish",
       "sns:receive",
       "sns:subscribe"
      ],
      "Condition": {
       "StringEquals": {
        "aws:principalorgid": [
         "o-exampleorgid"
        ]
       }
      },
      "Effect": "Allow",
      "Principal": {
       "AWS": [
        "*"
       ]
      },
      "Resource": [
       "arn:aws:sns:us-east-1:333333333333:topic-with-principalorgid-condition"
      ],
      "Sid": "AllowActionsWithinOrg"
     }
    ],
    "Version": "2012-10-17"
   }
  },
  {
   "policy_std": {
    "Id": "PrincipalAccountPolicy",
    "Statement": [
     {
      "Action": [
       "sns:publish",
       "sns:receive",
       "sns:subscribe"
      ],
      "Condition": {
       "StringEquals": {
        "aws:principalaccount": [
         "333333333333"
        ]
       }
      },
      "Effect": "Allow",
      "Principal": {
       "AWS": [
        "*"
       ]
      },
      "Resource": [
       "arn:aws:sns:us-east-1:333333333333:topic-with-principalaccount-condition"
      ],
      "Sid": "AllowActionsWithPrincipalAccount"
     }
    ],
    "Version": "2012-10-17"
   }
  },
  {
   "policy_std": {
    "Id": "SourceOwnerPolicy",
    "Statement": [
     {
      "Action": [
       "sns:publish"
      ],
      "Condition": {
       "StringEquals": {
        "aws:sourceowner": [
         "333333333333"
        ]
       }
      },
      "Effect": "Allow",
      "Principal": {
       "AWS": [
        "*"
       ]
      },
      "Resource": [
       "arn:aws:sns:us-east-1:333333333333:topic-with-sourceowner-condition"
      ],
      "Sid": "AllowPublishWithSourceOwner"
     }
    ],
    "Version": "2012-10-17"
   }
  },
  {
   "policy_std": {
    "Id": "MultipleConditionsPolicy",
    "Statement": [
     {
      "Action": [
       "sns:publish",
       "sns:receive",
       "sns:subscribe"
      ],
      "Condition": {
       "ArnLike": {
        "aws:sourcearn": [
         "arn:aws:*:*:333333333333:*"
        ]
       },
       "StringEquals": {
        "aws:principalaccount": [
         "333333333333"
        ]
       }
      },
      "Effect": "Allow",
      "Principal": {
       "AWS": [
        "*"
       ]
      },
      "Resource": [
       "arn:aws:sns:us-east-1:333333333333:topic-with-multiple-conditions"
      ],
      "Sid": "AllowActionsWithMultipleConditions"
     }
    ],
    "Version": "2012-10-17"
   }
  },
  {
   "policy_std": {
    "Id": "PrincipalArnPolicy",
    "Statement": [
     {
      "Action": [
       "sns:publish",
       "sns:receive",
       "sns:subscribe"
      ],
      "Condition": {
       "ArnLike": {
        "aws:principalarn": [
         "arn:aws:iam::333333333333:role/*"
        ]
       }
      },
      "Effect": "Allow",
      "Principal": {
       "AWS": [
        "*"
       ]
      },
      "Resource": [
       "arn:aws:sns:us-east-1:333333333333:topic-with-principalarn-condition"
      ],
      "Sid": "AllowWithPrincipalArn"
     }
    ],
    "Version": "2012-10-17"
   }
  },
  {
   "policy_std": {
    "Id": "SourceAccountPolicy",
    "Statement": [
     {
      "Action": [
       "sns:receive",
       "sns:subscribe"
      ],
      "Condition": {
       "StringEquals": {
        "aws:sourceaccount": [
         "333333333333"
        ]
       }
      },
      "Effect": "Allow",
      "Principal": {
       "AWS": [
        "*"
       ]
      },
      "Resource": [
       "arn:aws:sns:us-east-1:333333333333:topic-with-sourceaccount-condition"
      ],
      "Sid": "AllowSubscribeWithSourceAccount"
     }
    ],
    "Version": "2012-10-17"
   }
  },
  {
   "policy_std": {
    "Id": "SourceArnPolicy",
    "Statement": [
     {
      "Action": [
       "sns:publish"
      ],
      "Condition": {
       "ArnLike": {
        "aws:sourcearn": [
         "arn:aws:cloudwatch:*:333333333333:*"
        ]
       }
      },
      "Effect": "Allow",
      "Principal": {
       "AWS": [
        "*"
       ]
      },
      "Resource": [
       "arn:aws:sns:us-east-1:333333333333:topic-with-sourcearn-condition"
      ],
      "Sid": "AllowWithSourceArn"
     }
    ],
    "Version": "2012-10-17"
   }
  },
  {
   "policy_std": {
    "Id": "CrossAccountSourceArnPolicy",
    "Statement": [
     {
      "Action": [
       "sns:publish",
       "sns:receive",
       "sns:subscribe"
      ],
      "Condition": {
       "ArnLike": {
        "aws:sourcearn": [
         "arn:aws:*:*:333333333333:*"
        ]
       }
      },
      "Effect": "Allow",
      "Principal": {
       "AWS": [
        "arn:aws:iam::333333333333:root"
       ]
      },
      "Resource": [
       "arn:aws:sns:us-east-1:333333333333:topic-cross-account-sourcearn"
      ],
      "Sid": "AllowCrossAccountWithSourceArn"
     }
    ],
    "Version": "2012-10-17"
   }
  }
 ]
}
```