### PR TITLE
Fix: issue-#909 Access Key Rotation Scan Should Exclude Inactive Keys

### DIFF
--- a/conformance_pack/iam.pp
+++ b/conformance_pack/iam.pp
@@ -949,6 +949,8 @@ query "iam_user_access_key_age_90" {
       ${local.common_dimensions_global_sql}
     from
       aws_iam_access_key;
+    where
+      status='Active';
   EOQ
 }
 


### PR DESCRIPTION
### Checklist
- [ 909 ] Issue(s) linked


Access Key Rotation Scan Should Exclude Inactive Keys 