### PR TITLE
Fix query account_alternate_contact_security_registered to correctly list all the accounts closes #916

### DIFF
--- a/conformance_pack/account.pp
+++ b/conformance_pack/account.pp
@@ -66,10 +66,8 @@ query "account_alternate_contact_security_registered" {
       end as reason
       ${replace(local.common_dimensions_qualifier_global_sql, "__QUALIFIER__", "a.")}
     from
-      account as a,
-      alternate_security_contact as c
-    where
-      c.account_id = a.account_id;
+      account as a
+      left join alternate_security_contact as c on  c.account_id = a.account_id;;
   EOQ
 }
 


### PR DESCRIPTION
### Checklist
```
> with alternate_security_contact as (
      select
        name,
        account_id
      from
        aws_account_alternate_contact
      where
        contact_type = 'SECURITY'
    ),
    account as (
      select
        arn,
        partition,
        title,
        account_id,
        _ctx
      from
        aws_account
    )
    select
      arn as resource,
      case
        when a.partition = 'aws-us-gov' then 'info'
        -- Name is a required field if setting a security contact
        when c.name is not null then 'ok'
        else 'alarm'
      end as status,
      case
        when a.partition = 'aws-us-gov' then a.title || ' in GovCloud, manual verification required.'
        when c.name is not null then a.title || ' has security contact ' || c.name || ' registered.'
        else a.title || ' security contact not registered.'
      end as reason
    from
      account as a
      left join alternate_security_contact as c on  c.account_id = a.account_id;;
+------------------------+--------+----------------------------------------------------------------+
| resource               | status | reason                                                         |
+------------------------+--------+----------------------------------------------------------------+
| arn:aws:::12345678901 | alarm  | nagraj-aaa security contact not registered.                    |
| arn:aws:::12345678901 | ok     | 12345678901 has security contact testing_security registered. |
+------------------------+--------+----------------------------------------------------------------+

````
